### PR TITLE
Refactors the getCompletedRequests call

### DIFF
--- a/services/ec2/src/main/java/org/finra/gatekeeper/services/accessrequest/AccessRequestService.java
+++ b/services/ec2/src/main/java/org/finra/gatekeeper/services/accessrequest/AccessRequestService.java
@@ -20,6 +20,7 @@ import org.activiti.engine.HistoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.engine.TaskService;
 import org.activiti.engine.history.HistoricVariableInstance;
+import org.activiti.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
 import org.activiti.engine.task.Task;
 import org.finra.gatekeeper.common.services.account.AccountInformationService;
 import org.finra.gatekeeper.common.services.account.model.Account;
@@ -192,37 +193,78 @@ public class AccessRequestService {
     }
 
     public List<CompletedAccessRequestWrapper> getCompletedRequests() {
-        //We can use the variables stored on the activiti requests to build out our request history.
-        List<HistoricVariableInstance> taskVars = historyService.createHistoricVariableInstanceQuery().list();
-
+    /*  This object is all of the Activiti Variables associated with the request
+        This map will contain the following:
+        When the request was opened
+        When the request was actioned by an approver (or canceled by a user/approver)
+        How many attempts it took to approve the user*/
         Map<String, Map<String, Object>> historicData = new HashMap<>();
+
+        //we have to map the activiti hitory items to the gatekeeper requests map activiti objects to the access requests
+        Map<String, Long> activitiAccessRequestMap = new HashMap<>();
+        //map gatekeeper access request ids
+        Map<Long, AccessRequest> gkAccessRequestMap = new HashMap<>();
+
+    /*this gets all of the access requests history items. We exclude variable initialization
+        because activiti will break if we ever change the access request object so we'll just fetch the items
+        ourselves */
+        List<HistoricVariableInstance> accessRequests = historyService.createHistoricVariableInstanceQuery()
+                .excludeVariableInitialization()
+                .variableName("accessRequest")
+                .list();
+
+        //we'll get all the access requests and store the created date into the historicData map
+        //as well as map the activiti item to the access request to which it corresponds
+        accessRequests.forEach(taskVar -> {
+            Map<String, Object> data = new HashMap<>();
+            data.put("created", taskVar.getCreateTime());
+            historicData.put(taskVar.getProcessInstanceId(), data);
+            activitiAccessRequestMap.put(taskVar.getProcessInstanceId(), Long.valueOf(((HistoricVariableInstanceEntity) taskVar).getTextValue2()));
+        });
+
+        //run a query to grab all of the access requests that we found in activiti (this pretty much returns all
+        //for now, until we implement it to use a time window)
+        accessRequestRepository.findAll(activitiAccessRequestMap.values()).forEach(accessRequest -> {
+            gkAccessRequestMap.put(accessRequest.getId(), accessRequest);
+        });
+
+    /*  this one's kind of a hack but this query gets the RequestStatus value for a request
+        we do it like this because once again if the package name changes it won't update the database and will
+        activiti will try to instantiate the object using Reflection. to work around this we just pull out the value
+        for the enum and instantiate it ourselves
+
+        we also put the updated time into the historicData map here as this is when the request was updated
+     */
+        historyService.createNativeHistoricVariableInstanceQuery()
+                .sql("select a.*, substring(encode(b.bytes_, 'escape'), '\\w+$') as textValue\n" +
+                        "  from act_hi_varinst a join act_ge_bytearray b on a.bytearray_id_ = b.id_;\n")
+                .list()
+                .forEach(item -> {
+                    historicData.get(item.getProcessInstanceId()).put(item.getVariableName(), ((HistoricVariableInstanceEntity)item).getTextValue());
+                    historicData.get(item.getProcessInstanceId()).put("updated", item.getLastUpdatedTime());
+                });
+
+        //This gets all the attempts data for the requests and inserts it into the historicData map
+        historyService.createHistoricVariableInstanceQuery()
+                .excludeVariableInitialization()
+                .variableName("attempts")
+                .list()
+                .forEach(item -> {
+                    historicData.get(item.getProcessInstanceId()).put(item.getVariableName(), item.getValue());
+                });
+
 
         List<CompletedAccessRequestWrapper> results = new ArrayList<>();
 
-        taskVars.forEach(taskVar -> {
-            String key = taskVar.getVariableName();
-            Object value = taskVar.getValue();
-
-            if (historicData.containsKey(taskVar.getProcessInstanceId())) {
-                historicData.get(taskVar.getProcessInstanceId()).put(taskVar.getVariableName(), taskVar.getValue());
-            } else {
-                Map<String, Object> data = new HashMap<>();
-                data.put("created", taskVar.getCreateTime());
-                data.put(taskVar.getVariableName(), taskVar.getValue());
-                historicData.put(taskVar.getProcessInstanceId(), data);
-            }
-
-            if (key.equals("requestStatus")) {
-                historicData.get(taskVar.getProcessInstanceId()).put("updated", taskVar.getLastUpdatedTime());
-            }
-        });
-
+        //this section compiles the historicData into the response object for the UI to consume
         for (String k : historicData.keySet()) {
             Map<String, Object> varMap = historicData.get(k);
-            RequestStatus status = (RequestStatus) varMap.get("requestStatus") != null
-                    ? (RequestStatus) varMap.get("requestStatus") : RequestStatus.APPROVAL_PENDING;
+            //we instantiate the RequestStatus value here.
+            RequestStatus status = varMap.get("requestStatus") != null
+                    ? RequestStatus.valueOf((String)varMap.get("requestStatus"))
+                    : RequestStatus.APPROVAL_PENDING;
 
-            AccessRequest request = (AccessRequest) varMap.get("accessRequest");
+            AccessRequest request = gkAccessRequestMap.get(activitiAccessRequestMap.get(k));
             if(status.equals(RequestStatus.APPROVAL_PENDING)){
                 request=updateInstanceStatus(request);
             }

--- a/services/ec2/src/main/java/org/finra/gatekeeper/services/accessrequest/AccessRequestService.java
+++ b/services/ec2/src/main/java/org/finra/gatekeeper/services/accessrequest/AccessRequestService.java
@@ -180,8 +180,10 @@ public class AccessRequestService {
         List<Task> tasks = taskService.createTaskQuery().active().list();
         List<ActiveAccessRequestWrapper> response = new ArrayList<>();
         tasks.forEach(task -> {
-            AccessRequest theRequest = updateInstanceStatus((AccessRequest) runtimeService.getVariable(task.getExecutionId(), "accessRequest"));
-
+            AccessRequest theRequest = updateInstanceStatus(
+                    accessRequestRepository.findOne(Long.valueOf(
+                            runtimeService.getVariableInstance(task.getExecutionId(), "accessRequest").getTextValue2())
+                    ));
             response.add(new ActiveAccessRequestWrapper(theRequest)
                     .setCreated(task.getCreateTime())
                     .setTaskId(task.getId())
@@ -259,27 +261,33 @@ public class AccessRequestService {
         //this section compiles the historicData into the response object for the UI to consume
         for (String k : historicData.keySet()) {
             Map<String, Object> varMap = historicData.get(k);
-            //we instantiate the RequestStatus value here.
-            RequestStatus status = varMap.get("requestStatus") != null
-                    ? RequestStatus.valueOf((String)varMap.get("requestStatus"))
-                    : RequestStatus.APPROVAL_PENDING;
-
+            Long requestId = activitiAccessRequestMap.get(k);
             AccessRequest request = gkAccessRequestMap.get(activitiAccessRequestMap.get(k));
-            if(status.equals(RequestStatus.APPROVAL_PENDING)){
-                request=updateInstanceStatus(request);
+
+            if(request != null ) {
+                //we instantiate the RequestStatus value here.
+                RequestStatus status = varMap.get("requestStatus") != null
+                        ? RequestStatus.valueOf((String) varMap.get("requestStatus"))
+                        : RequestStatus.APPROVAL_PENDING;
+
+                if (status.equals(RequestStatus.APPROVAL_PENDING)) {
+                    request = updateInstanceStatus(request);
+                }
+                Date created = (Date) varMap.get("created");
+                Date updated = (Date) varMap.get("updated");
+                CompletedAccessRequestWrapper wrapper = new CompletedAccessRequestWrapper(request)
+                        .setUpdated(updated)
+                        .setAttempts((Integer) varMap.get("attempts"))
+                        .setStatus(status)
+                        .setActionedByUserId(request.getActionedByUserId())
+                        .setActionedByUserName(request.getActionedByUserName());
+
+                wrapper.setCreated(created);
+
+                results.add(wrapper);
+            } else {
+                logger.warn("Could not get request details for AccessRequest with ID: " + requestId + ". This request will not be returned ");
             }
-            Date created = (Date) varMap.get("created");
-            Date updated = (Date) varMap.get("updated");
-            CompletedAccessRequestWrapper wrapper = new CompletedAccessRequestWrapper(request)
-                    .setUpdated(updated)
-                    .setAttempts((Integer) varMap.get("attempts"))
-                    .setStatus(status)
-                    .setActionedByUserId(request.getActionedByUserId())
-                    .setActionedByUserName(request.getActionedByUserName());
-
-            wrapper.setCreated(created);
-
-            results.add(wrapper);
         }
 
         return (List<CompletedAccessRequestWrapper>)filterResults(results);

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/AccessRequestService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/AccessRequestService.java
@@ -21,6 +21,7 @@ import org.activiti.engine.HistoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.engine.TaskService;
 import org.activiti.engine.history.HistoricVariableInstance;
+import org.activiti.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
 import org.activiti.engine.task.Task;
 import org.finra.gatekeeper.common.services.user.model.GatekeeperUserEntry;
 import org.finra.gatekeeper.configuration.GatekeeperApprovalProperties;
@@ -239,38 +240,78 @@ public class AccessRequestService {
     }
 
     public List<CompletedAccessRequestWrapper> getCompletedRequests() {
-        //We can use the variables stored on the activiti requests to build out our request history.
-        List<HistoricVariableInstance> taskVars = historyService.createHistoricVariableInstanceQuery().list();
-
+    /*  This object is all of the Activiti Variables associated with the request
+        This map will contain the following:
+        When the request was opened
+        When the request was actioned by an approver (or canceled by a user/approver)
+        How many attempts it took to approve the user*/
         Map<String, Map<String, Object>> historicData = new HashMap<>();
+
+        //we have to map the activiti hitory items to the gatekeeper requests map activiti objects to the access requests
+        Map<String, Long> activitiAccessRequestMap = new HashMap<>();
+        //map gatekeeper access request ids
+        Map<Long, AccessRequest> gkAccessRequestMap = new HashMap<>();
+
+    /*this gets all of the access requests history items. We exclude variable initialization
+        because activiti will break if we ever change the access request object so we'll just fetch the items
+        ourselves */
+        List<HistoricVariableInstance> accessRequests = historyService.createHistoricVariableInstanceQuery()
+                .excludeVariableInitialization()
+                .variableName("accessRequest")
+                .list();
+
+        //we'll get all the access requests and store the created date into the historicData map
+        //as well as map the activiti item to the access request to which it corresponds
+        accessRequests.forEach(taskVar -> {
+            Map<String, Object> data = new HashMap<>();
+            data.put("created", taskVar.getCreateTime());
+            historicData.put(taskVar.getProcessInstanceId(), data);
+            activitiAccessRequestMap.put(taskVar.getProcessInstanceId(), Long.valueOf(((HistoricVariableInstanceEntity) taskVar).getTextValue2()));
+        });
+
+        //run a query to grab all of the access requests that we found in activiti (this pretty much returns all
+        //for now, until we implement it to use a time window)
+        accessRequestRepository.findAll(activitiAccessRequestMap.values()).forEach(accessRequest -> {
+            gkAccessRequestMap.put(accessRequest.getId(), accessRequest);
+        });
+
+    /*  this one's kind of a hack but this query gets the RequestStatus value for a request
+        we do it like this because once again if the package name changes it won't update the database and will
+        activiti will try to instantiate the object using Reflection. to work around this we just pull out the value
+        for the enum and instantiate it ourselves
+
+        we also put the updated time into the historicData map here as this is when the request was updated
+     */
+        historyService.createNativeHistoricVariableInstanceQuery()
+                .sql("select a.*, substring(encode(b.bytes_, 'escape'), '\\w+$') as textValue\n" +
+                        "  from act_hi_varinst a join act_ge_bytearray b on a.bytearray_id_ = b.id_;\n")
+                .list()
+                .forEach(item -> {
+                    historicData.get(item.getProcessInstanceId()).put(item.getVariableName(), ((HistoricVariableInstanceEntity)item).getTextValue());
+                    historicData.get(item.getProcessInstanceId()).put("updated", item.getLastUpdatedTime());
+                });
+
+        //This gets all the attempts data for the requests and inserts it into the historicData map
+        historyService.createHistoricVariableInstanceQuery()
+                .excludeVariableInitialization()
+                .variableName("attempts")
+                .list()
+                .forEach(item -> {
+                    historicData.get(item.getProcessInstanceId()).put(item.getVariableName(), item.getValue());
+                });
+
 
         List<CompletedAccessRequestWrapper> results = new ArrayList<>();
 
-        taskVars.forEach(taskVar -> {
-            String key = taskVar.getVariableName();
-            Object value = taskVar.getValue();
-
-            if (historicData.containsKey(taskVar.getProcessInstanceId())) {
-                historicData.get(taskVar.getProcessInstanceId()).put(taskVar.getVariableName(), taskVar.getValue());
-            } else {
-                Map<String, Object> data = new HashMap<>();
-                data.put("created", taskVar.getCreateTime());
-                data.put(taskVar.getVariableName(), taskVar.getValue());
-                historicData.put(taskVar.getProcessInstanceId(), data);
-            }
-
-            if (key.equals("requestStatus")) {
-                historicData.get(taskVar.getProcessInstanceId()).put("updated", taskVar.getLastUpdatedTime());
-            }
-        });
-
+        //this section compiles the historicData into the response object for the UI to consume
         for (String k : historicData.keySet()) {
             Map<String, Object> varMap = historicData.get(k);
-            RequestStatus status = (RequestStatus) varMap.get("requestStatus") != null
-                    ? (RequestStatus) varMap.get("requestStatus") : RequestStatus.APPROVAL_PENDING;
+            //we instantiate the RequestStatus value here.
+            RequestStatus status = varMap.get("requestStatus") != null
+                    ? RequestStatus.valueOf((String)varMap.get("requestStatus"))
+                    : RequestStatus.APPROVAL_PENDING;
 
-            AccessRequest request = (AccessRequest) varMap.get("accessRequest");
-
+            AccessRequest request = gkAccessRequestMap.get(activitiAccessRequestMap.get(k));
             Date created = (Date) varMap.get("created");
             Date updated = (Date) varMap.get("updated");
             CompletedAccessRequestWrapper wrapper = new CompletedAccessRequestWrapper(request)
@@ -278,7 +319,7 @@ public class AccessRequestService {
                     .setAttempts((Integer) varMap.get("attempts"))
                     .setStatus(status)
                     .setActionedByUserId(request.getActionedByUserId())
-                    .setActionedByUserName(request.getActionedByUserName());;
+                    .setActionedByUserName(request.getActionedByUserName());
 
             wrapper.setCreated(created);
 

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/accessrequest/AccessRequestServiceTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/accessrequest/AccessRequestServiceTest.java
@@ -22,6 +22,8 @@ import org.activiti.engine.RuntimeService;
 import org.activiti.engine.TaskService;
 import org.activiti.engine.history.HistoricVariableInstance;
 import org.activiti.engine.history.HistoricVariableInstanceQuery;
+import org.activiti.engine.history.NativeHistoricVariableInstanceQuery;
+import org.activiti.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
 import org.activiti.engine.runtime.ProcessInstanceQuery;
 import org.activiti.engine.task.Task;
 import org.activiti.engine.task.TaskQuery;
@@ -108,22 +110,25 @@ public class AccessRequestServiceTest {
     private HistoricVariableInstanceQuery historicVariableInstanceQuery;
 
     @Mock
-    private HistoricVariableInstance ownerHistoricVariableInstanceAttempt;
+    private NativeHistoricVariableInstanceQuery nativeHistoricVariableInstanceQuery;
 
     @Mock
-    private HistoricVariableInstance ownerHistoricVariableInstanceStatus;
+    private HistoricVariableInstanceEntity ownerHistoricVariableInstanceAttempt;
 
     @Mock
-    private HistoricVariableInstance ownerHistoricVariableInstanceAccessRequest;
+    private HistoricVariableInstanceEntity ownerHistoricVariableInstanceStatus;
 
     @Mock
-    private HistoricVariableInstance nonOwnerHistoricVariableInstanceAttempt;
+    private HistoricVariableInstanceEntity ownerHistoricVariableInstanceAccessRequest;
 
     @Mock
-    private HistoricVariableInstance nonOwnerHistoricVariableInstanceStatus;
+    private HistoricVariableInstanceEntity nonOwnerHistoricVariableInstanceAttempt;
 
     @Mock
-    private HistoricVariableInstance nonOwnerHistoricVariableInstanceAccessRequest;
+    private HistoricVariableInstanceEntity nonOwnerHistoricVariableInstanceStatus;
+
+    @Mock
+    private HistoricVariableInstanceEntity nonOwnerHistoricVariableInstanceAccessRequest;
 
     @Mock
     private GatekeeperOverrideProperties overridePolicy;
@@ -265,20 +270,30 @@ public class AccessRequestServiceTest {
         when(ownerHistoricVariableInstanceAttempt.getValue()).thenReturn(1);
         when(ownerHistoricVariableInstanceAttempt.getVariableName()).thenReturn("attempts");
         when(ownerHistoricVariableInstanceAttempt.getCreateTime()).thenReturn(new Date(45000));
-        when(ownerHistoricVariableInstanceStatus.getValue()).thenReturn(RequestStatus.APPROVAL_GRANTED);
+        when(ownerHistoricVariableInstanceAttempt.getTextValue2()).thenReturn("1");
+        when(ownerHistoricVariableInstanceStatus.getValue()).thenReturn("APPROVAL_GRANTED");
         when(ownerHistoricVariableInstanceStatus.getVariableName()).thenReturn("requestStatus");
         when(ownerHistoricVariableInstanceStatus.getLastUpdatedTime()).thenReturn(new Date(45002));
+        when(ownerHistoricVariableInstanceStatus.getTextValue2()).thenReturn("1");
         when(ownerHistoricVariableInstanceAccessRequest.getValue()).thenReturn(ownerRequest);
         when(ownerHistoricVariableInstanceAccessRequest.getVariableName()).thenReturn("accessRequest");
+        when(ownerHistoricVariableInstanceAccessRequest.getCreateTime()).thenReturn(new Date(45000));
+        when(ownerHistoricVariableInstanceAccessRequest.getTextValue2()).thenReturn("1");
+        when(ownerHistoricVariableInstanceAccessRequest.getLastUpdatedTime()).thenReturn(new Date(45002));
 
         when(nonOwnerHistoricVariableInstanceAttempt.getValue()).thenReturn(2);
         when(nonOwnerHistoricVariableInstanceAttempt.getVariableName()).thenReturn("attempts");
         when(nonOwnerHistoricVariableInstanceAttempt.getCreateTime()).thenReturn(new Date(45002));
+        when(nonOwnerHistoricVariableInstanceAttempt.getTextValue2()).thenReturn("2");
         when(nonOwnerHistoricVariableInstanceStatus.getValue()).thenReturn(null);
         when(nonOwnerHistoricVariableInstanceStatus.getVariableName()).thenReturn("requestStatus");
         when(nonOwnerHistoricVariableInstanceStatus.getLastUpdatedTime()).thenReturn(new Date(45003));
+        when(nonOwnerHistoricVariableInstanceStatus.getTextValue2()).thenReturn("2");
         when(nonOwnerHistoricVariableInstanceAccessRequest.getValue()).thenReturn(nonOwnerRequest);
         when(nonOwnerHistoricVariableInstanceAccessRequest.getVariableName()).thenReturn("accessRequest");
+        when(nonOwnerHistoricVariableInstanceAccessRequest.getCreateTime()).thenReturn(new Date(45002));
+        when(nonOwnerHistoricVariableInstanceAccessRequest.getTextValue2()).thenReturn("2");
+        when(nonOwnerHistoricVariableInstanceAccessRequest.getLastUpdatedTime()).thenReturn(new Date(45003));
 
         taskVars.add(ownerHistoricVariableInstanceAttempt);
         taskVars.add(ownerHistoricVariableInstanceStatus);
@@ -290,11 +305,16 @@ public class AccessRequestServiceTest {
 
         when(historyService.createHistoricVariableInstanceQuery()).thenReturn(historicVariableInstanceQuery);
         when(historyService.createHistoricVariableInstanceQuery().list()).thenReturn(taskVars);
+        when(historicVariableInstanceQuery.excludeVariableInitialization()).thenReturn(historicVariableInstanceQuery);
+        when(historicVariableInstanceQuery.variableName(Mockito.any())).thenReturn(historicVariableInstanceQuery);
+        when(historyService.createNativeHistoricVariableInstanceQuery()).thenReturn(nativeHistoricVariableInstanceQuery);
+        when(nativeHistoricVariableInstanceQuery.sql(Mockito.any())).thenReturn(nativeHistoricVariableInstanceQuery);
+        when(nativeHistoricVariableInstanceQuery.list()).thenReturn(taskVars);
         Map<String,String> statusMap = new HashMap<>();
         statusMap.put("testId","Unknown");
 
         when(accountInformationService.getAccountByAlias(any())).thenReturn(mockAccount);
-
+        when(accessRequestRepository.findAll(Mockito.anyList())).thenReturn(Arrays.asList(ownerRequest, nonOwnerRequest));
     }
 
 

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/accessrequest/AccessRequestServiceTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/accessrequest/AccessRequestServiceTest.java
@@ -24,6 +24,7 @@ import org.activiti.engine.history.HistoricVariableInstance;
 import org.activiti.engine.history.HistoricVariableInstanceQuery;
 import org.activiti.engine.history.NativeHistoricVariableInstanceQuery;
 import org.activiti.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
+import org.activiti.engine.impl.persistence.entity.VariableInstance;
 import org.activiti.engine.runtime.ProcessInstanceQuery;
 import org.activiti.engine.task.Task;
 import org.activiti.engine.task.TaskQuery;
@@ -129,6 +130,13 @@ public class AccessRequestServiceTest {
 
     @Mock
     private HistoricVariableInstanceEntity nonOwnerHistoricVariableInstanceAccessRequest;
+
+    @Mock
+    private VariableInstance ownerOneTaskInstance;
+
+    @Mock
+    private VariableInstance ownerTwoTaskInstance;
+
 
     @Mock
     private GatekeeperOverrideProperties overridePolicy;
@@ -245,8 +253,14 @@ public class AccessRequestServiceTest {
         when(ownerTwoTask.getCreateTime()).thenReturn(testDate);
         when(ownerTwoTask.getId()).thenReturn("taskTwo");
 
-        when(runtimeService.getVariable("ownerOneTask", "accessRequest")).thenReturn(ownerRequest);
-        when(runtimeService.getVariable("ownerTwoTask", "accessRequest")).thenReturn(nonOwnerRequest);
+        when(ownerOneTaskInstance.getTextValue2()).thenReturn("1");
+        when(ownerTwoTaskInstance.getTextValue2()).thenReturn("2");
+
+        when(accessRequestRepository.findOne(1L)).thenReturn(ownerRequest);
+        when(accessRequestRepository.findOne(2L)).thenReturn(nonOwnerRequest);
+
+        when(runtimeService.getVariableInstance("ownerOneTask", "accessRequest")).thenReturn(ownerOneTaskInstance);
+        when(runtimeService.getVariableInstance("ownerTwoTask", "accessRequest")).thenReturn(ownerTwoTaskInstance);
 
 
         List<Task> activeTasks = new ArrayList<>();
@@ -658,7 +672,7 @@ public class AccessRequestServiceTest {
      */
     @Test
     public void testApproval(){
-        Mockito.when(accessRequestRepository.findOne(1L)).thenReturn(new AccessRequest());
+        Mockito.when(accessRequestRepository.findOne(1L)).thenReturn(ownerRequest);
         accessRequestService.approveRequest("taskOne", 1L, "A reason");
         Map<String,Object> statusMap = new HashMap<>();
         statusMap.put("requestStatus", RequestStatus.APPROVAL_GRANTED);
@@ -673,7 +687,7 @@ public class AccessRequestServiceTest {
      */
     @Test
     public void testRejected(){
-        Mockito.when(accessRequestRepository.findOne(1L)).thenReturn(new AccessRequest());
+        Mockito.when(accessRequestRepository.findOne(1L)).thenReturn(ownerRequest);
         accessRequestService.rejectRequest("taskOne", 1L, "Another Reason");
         Map<String,Object> statusMap = new HashMap<>();
         statusMap.put("requestStatus", RequestStatus.APPROVAL_REJECTED);


### PR DESCRIPTION
#18 

Refactors the getCompletedRequests call to be more resilient in the face of package changes (Don't let activiti use it's reflection library and instead instantiate the objects ourselves)

Signed-off-by: Stephen Mele <Smelecs@gmail.com>