### PR TITLE
Fix double logging + replaces the old travis badge with a circle CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="/img/logo.png" alt="drawing" width="500px"/>
 
-[![Build Status](https://secure.travis-ci.org/FINRAOS/Gatekeeper.png?branch=master)](http://travis-ci.org/FINRAOS/Gatekeeper)
+[![CircleCI](https://circleci.com/gh/FINRAOS/Gatekeeper/tree/master.svg?style=svg)](https://circleci.com/gh/FINRAOS/Gatekeeper/tree/master)
 
 ## What is Gatekeeper?
 Gatekeeper is self-serviced web application allowing users to make requests for temporary access to EC2/RDS instances running in AWS and gain access instantly.

--- a/services/ec2/src/main/resources/logback.xml
+++ b/services/ec2/src/main/resources/logback.xml
@@ -21,9 +21,8 @@
 
     <root level="INFO">
         <appender-ref ref="CONSOLE" />
-        <appender-ref ref="FILE" />
+        <!--<appender-ref ref="FILE" />-->
     </root>
-
     <!--<root level="DEBUG">-->
         <!--<appender-ref ref="CONSOLE" />-->
         <!--<appender-ref ref="FILE" />-->

--- a/services/rds/src/main/resources/logback.xml
+++ b/services/rds/src/main/resources/logback.xml
@@ -21,6 +21,6 @@
 
     <root level="INFO">
         <appender-ref ref="CONSOLE" />
-        <appender-ref ref="FILE" />
+    <!--<appender-ref ref="FILE" /> -->
     </root>
 </configuration>


### PR DESCRIPTION
Gatekeeper logs twice to its logging file, because the INFO appender is logging out to the FILE as well.

Signed-off-by: Stephen Mele <Smelecs@gmail.com>