### PR TITLE
Make hours configurable for ec2 service

### DIFF
--- a/aws/ssm/GK-Create.json
+++ b/aws/ssm/GK-Create.json
@@ -13,6 +13,11 @@
       "description":"(Required) The public key string for the user.",
       "maxChars":4096
     },
+    "hours":{
+      "type":"String",
+      "description":"(Required) The amount of time to give the user access",
+      "default": "24"
+    },
     "executionTimeout":{
       "type":"String",
       "default":"300",
@@ -26,7 +31,7 @@
         {
           "id":"0.aws:runShellScript",
           "runCommand":[
-            "useradd -e `date -d '+2 days' '+%Y-%m-%d'` {{ userName }} -m",
+            "useradd -e `date -d \"+$((({{hours}} / 24) + 1)) days\" '+%Y-%m-%d'` {{ userName }} -m",
             "mkdir /home/{{ userName }}/.ssh",
             "echo '{{ publicKey }}' >> /home/{{ userName }}/.ssh/authorized_keys",
             "chown -R {{ userName }}:{{ userName }} /home/{{ userName }}",

--- a/services/ec2/src/main/java/org/finra/gatekeeper/services/accessrequest/delegates/GrantAccessServiceTask.java
+++ b/services/ec2/src/main/java/org/finra/gatekeeper/services/accessrequest/delegates/GrantAccessServiceTask.java
@@ -143,7 +143,7 @@ public class GrantAccessServiceTask implements JavaDelegate {
             String privateKeyString = keypairService.getPEM(privKey);
 
             // Call SSM to create account (one call does all instances)
-            Map<String, String> createStatus = ssmService.createUserAccount(env, instances, u.getUserId(), publicKeyString, platform);
+            Map<String, String> createStatus = ssmService.createUserAccount(env, instances, u.getUserId(), publicKeyString, platform, accessRequest.getHours().toString());
             userStatus.put(u.getName(), createStatus.containsValue(CommandStatus.Success.toString()));
 
             // Send email with private key

--- a/services/ec2/src/main/java/org/finra/gatekeeper/services/aws/SsmService.java
+++ b/services/ec2/src/main/java/org/finra/gatekeeper/services/aws/SsmService.java
@@ -102,13 +102,14 @@ public class SsmService {
      * @param platform the platform used to determine the document to be executed
      * @return True or false based on whether the user was added to all instances
      */
-    public Map<String, String> createUserAccount(AWSEnvironment environment, List<String> instanceIds, String userName, String publicKey, String platform) {
-        logger.info("Creating user account: " + userName + " on "+ platform +" instances: " + instanceIds + " on environment: " + environment);
+    public Map<String, String> createUserAccount(AWSEnvironment environment, List<String> instanceIds, String userName, String publicKey, String platform, String hours) {
+        logger.info("Creating user account: " + userName + " on "+ platform +" instances: " + instanceIds + " on environment: " + environment + " for hours: " + hours);
 
 
         GatekeeperSsmProperties.SsmDocument documentProperties = getSsmDocument(platform, "create");
 
         Map<String, ArrayList<String>> parameters = new HashMap<>();
+        parameters.put("hours", Lists.newArrayList(hours));
         parameters.put("userName", Lists.newArrayList(userName));
         parameters.put("publicKey", Lists.newArrayList(publicKey));
         parameters.put("executionTimeout", Lists.newArrayList(Integer.toString(documentProperties.getTimeout())));

--- a/services/ec2/src/test/java/org/finra/gatekeeper/services/aws/SsmServiceTest.java
+++ b/services/ec2/src/test/java/org/finra/gatekeeper/services/aws/SsmServiceTest.java
@@ -185,7 +185,7 @@ public class SsmServiceTest {
 
     @Test
     public void testCreateUserAccount(){
-        Map<String, String> results = ssmService.createUserAccount(awsEnvironment, Arrays.asList("i-1","i-2"), "theUser", "HelloKey", "Linux");
+        Map<String, String> results = ssmService.createUserAccount(awsEnvironment, Arrays.asList("i-1","i-2"), "theUser", "HelloKey", "Linux", "23");
         Assert.assertTrue("Verify that the ssm succeeds for Linux", results.containsValue("Success"));
 
 
@@ -194,6 +194,7 @@ public class SsmServiceTest {
                 .withDocumentName("test-linux-create")
                 .addParametersEntry("userName",Arrays.asList("theUser"))
                 .addParametersEntry("publicKey",Arrays.asList("HelloKey"))
+                .addParametersEntry("hours", Arrays.asList("23"))
                 .addParametersEntry("executionTimeout",Arrays.asList("15"));
         verify(awsSimpleSystemsManagementClient, times(1)).sendCommand(scr);
 
@@ -227,7 +228,7 @@ public class SsmServiceTest {
         fakeCommand2.setStatus(CommandInvocationStatus.Success);
         fakeCommandList.setCommandInvocations(Arrays.asList(fakeCommand1, fakeCommand2));
         when(awsSimpleSystemsManagementClient.listCommandInvocations(anyObject())).thenReturn(fakeCommandList);
-        Map<String, String> results = ssmService.createUserAccount(awsEnvironment, Arrays.asList("i-1","i-2"), "theUser", "HelloKey", "Linux");
+        Map<String, String> results = ssmService.createUserAccount(awsEnvironment, Arrays.asList("i-1","i-2"), "theUser", "HelloKey", "Linux", "23");
         Assert.assertFalse("Verify that the ssm reports false and times out", !results.containsValue("Success"));
     }
 
@@ -236,7 +237,7 @@ public class SsmServiceTest {
         ListCommandInvocationsResult timeout = new ListCommandInvocationsResult();
         timeout.setCommandInvocations(new ArrayList<>());
         when(awsSimpleSystemsManagementClient.listCommandInvocations(anyObject())).thenReturn(timeout);
-        Map<String, String> results = ssmService.createUserAccount(awsEnvironment, Arrays.asList("i-1","i-2"), "theUser", "HelloKey", "Linux");
+        Map<String, String> results = ssmService.createUserAccount(awsEnvironment, Arrays.asList("i-1","i-2"), "theUser", "HelloKey", "Linux", "23");
         Assert.assertFalse("Verify that the ssm reports false and times out",results.containsValue("Success"));
     }
 


### PR DESCRIPTION
right now the SSM doc on Linux always expires the user after 2 days, this update makes the app send the hours as a parameter to the document so that the script's backout expire time is more intelligent.