### PR TITLE
Update to support new confidential readonly / dba roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,41 +342,65 @@ Like the EC2 service, the RDS approval criteria needs to be set, however this co
 Here is an example from [config/rds_service_config.env](config/rds_service_config.env) 
 
 ```dotenv
-    gatekeeper.approvalThreshold.dev.readonly.dev=120
-    gatekeeper.approvalThreshold.dev.readonly.qa=100
-    gatekeeper.approvalThreshold.dev.readonly.prod=-1
+gatekeeper.approvalThreshold.dev.readonly.dev=120
+gatekeeper.approvalThreshold.dev.readonly.qa=100
+gatekeeper.approvalThreshold.dev.readonly.prod=-1
 
-    gatekeeper.approvalThreshold.dev.datafix.dev=180
-    gatekeeper.approvalThreshold.dev.datafix.qa=180
-    gatekeeper.approvalThreshold.dev.datafix.prod=-1
-    
-    gatekeeper.approvalThreshold.dev.dba.dev=180
-    gatekeeper.approvalThreshold.dev.dba.qa=2
-    gatekeeper.approvalThreshold.dev.dba.prod=-1
-    
-    gatekeeper.approvalThreshold.ops.readonly.dev=-1
-    gatekeeper.approvalThreshold.ops.readonly.qa=-1
-    gatekeeper.approvalThreshold.ops.readonly.prod=180
-    
-    gatekeeper.approvalThreshold.ops.datafix.dev=-1
-    gatekeeper.approvalThreshold.ops.datafix.qa=-1
-    gatekeeper.approvalThreshold.ops.datafix.prod=1
-    
-    gatekeeper.approvalThreshold.ops.dba.dev=-1
-    gatekeeper.approvalThreshold.ops.dba.qa=-1
-    gatekeeper.approvalThreshold.ops.dba.prod=-1
-    
-    gatekeeper.approvalThreshold.dba.readonly.dev=180
-    gatekeeper.approvalThreshold.dba.readonly.qa=180
-    gatekeeper.approvalThreshold.dba.readonly.prod=180
-    
-    gatekeeper.approvalThreshold.dba.datafix.dev=180
-    gatekeeper.approvalThreshold.dba.datafix.qa=180
-    gatekeeper.approvalThreshold.dba.datafix.prod=180
-    
-    gatekeeper.approvalThreshold.dba.dba.dev=180
-    gatekeeper.approvalThreshold.dba.dba.qa=180
-    gatekeeper.approvalThreshold.dba.dba.prod=-1
+gatekeeper.approvalThreshold.dev.readonly_confidential.dev=50
+gatekeeper.approvalThreshold.dev.readonly_confidential.qa=20
+gatekeeper.approvalThreshold.dev.readonly_confidential.prod=-1
+
+gatekeeper.approvalThreshold.dev.datafix.dev=180
+gatekeeper.approvalThreshold.dev.datafix.qa=180
+gatekeeper.approvalThreshold.dev.datafix.prod=-1
+
+gatekeeper.approvalThreshold.dev.dba.dev=180
+gatekeeper.approvalThreshold.dev.dba.qa=2
+gatekeeper.approvalThreshold.dev.dba.prod=-1
+
+gatekeeper.approvalThreshold.dev.dba_confidential.dev=-1
+gatekeeper.approvalThreshold.dev.dba_confidential.qa=-1
+gatekeeper.approvalThreshold.dev.dba_confidential.prod=-1
+
+gatekeeper.approvalThreshold.ops.readonly.dev=-1
+gatekeeper.approvalThreshold.ops.readonly.qa=-1
+gatekeeper.approvalThreshold.ops.readonly.prod=180
+
+gatekeeper.approvalThreshold.ops.readonly_confidential.dev=75
+gatekeeper.approvalThreshold.ops.readonly_confidential.qa=50
+gatekeeper.approvalThreshold.ops.readonly_confidential.prod=-1
+
+gatekeeper.approvalThreshold.ops.datafix.dev=-1
+gatekeeper.approvalThreshold.ops.datafix.qa=-1
+gatekeeper.approvalThreshold.ops.datafix.prod=1
+
+gatekeeper.approvalThreshold.ops.dba.dev=-1
+gatekeeper.approvalThreshold.ops.dba.qa=-1
+gatekeeper.approvalThreshold.ops.dba.prod=-1
+
+gatekeeper.approvalThreshold.ops.dba_confidential.dev=-1
+gatekeeper.approvalThreshold.ops.dba_confidential.qa=-1
+gatekeeper.approvalThreshold.ops.dba_confidential.prod=-1
+
+gatekeeper.approvalThreshold.dba.readonly.dev=180
+gatekeeper.approvalThreshold.dba.readonly.qa=180
+gatekeeper.approvalThreshold.dba.readonly.prod=180
+
+gatekeeper.approvalThreshold.dba.readonly_confidential.dev=100
+gatekeeper.approvalThreshold.dba.readonly_confidential.qa=125
+gatekeeper.approvalThreshold.dba.readonly_confidential.prod=1
+
+gatekeeper.approvalThreshold.dba.datafix.dev=180
+gatekeeper.approvalThreshold.dba.datafix.qa=180
+gatekeeper.approvalThreshold.dba.datafix.prod=180
+
+gatekeeper.approvalThreshold.dba.dba.dev=180
+gatekeeper.approvalThreshold.dba.dba.qa=180
+gatekeeper.approvalThreshold.dba.dba.prod=-1
+
+gatekeeper.approvalThreshold.dba.dba_confidential.dev=180
+gatekeeper.approvalThreshold.dba.dba_confidential.qa=180
+gatekeeper.approvalThreshold.dba.dba_confidential.prod=-1
 ```
 Here's an explanation of what this configuration translates to in Gatekeeper:
 
@@ -384,6 +408,10 @@ Here's an explanation of what this configuration translates to in Gatekeeper:
     - Requesting readonly
         - < 120 days for dev environment
         - < 180 days for qa environment
+        - approval is **always** required for prod
+    - Requesting readonly_confidential
+        - <= 50 days for dev environment
+        - <= 20 days for qa environment
         - approval is **always** required for prod
     - Requesting datafix
         - <= 180 days for dev environment
@@ -393,12 +421,19 @@ Here's an explanation of what this configuration translates to in Gatekeeper:
         - <= 180 days for dev environment
         - <= 2 days for qa environment
         - approval is **always** required for prod
-          
+    - Requesting dba_confidential
+        - approval is **always** required for dev
+        - approval is **always** required for qa
+        - approval is **always** required for prod
 2. For Ops Role
     - Requesting readonly
         - approval is **always** required for dev
         - approval is **always** required for qa
         - <= 180 days for prod
+    - Requesting readonly_confidential
+        - <= 75 days for dev environment
+        - <= 50 days for qa environment
+        - approval is **always** required for prod
     - Requesting datafix
         - approval is **always** required for dev
         - approval is **always** required for qa
@@ -407,16 +442,28 @@ Here's an explanation of what this configuration translates to in Gatekeeper:
         - approval is **always** required for dev
         - approval is **always** required for qa
         - approval is **always** required for prod
+    - Requesting dba_confidential
+        - approval is **always** required for dev
+        - approval is **always** required for qa
+        - approval is **always** required for prod
 3. For DBA Role
     - Requesting readonly
         - <= 180 days for dev environment
         - <= 180 days for qa environment
         - <= 180 days for prod environment
+    - Requesting readonly_confidential
+        - <= 100 days for dev environment
+        - <= 125 days for qa environment
+        - approval is **always** required for prod        
     - Requesting datafix
         - <= 180 days for dev environment
         - <= 180 days for qa environment
         - <= 180 days for prod environment
     - Requesting dba
+        - <= 180 days for dev environment
+        - <= 180 days for qa environment
+        - approval is **always** required for prod
+    - Requesting dba_confidential
         - <= 180 days for dev environment
         - <= 180 days for qa environment
         - approval is **always** required for prod
@@ -426,13 +473,19 @@ You can see the format for these properties below:
 | Property | Description | Type |
 |----------|-------------|------|
 | gatekeeper.approvalThreshold.dev.readonly.<environment>| The threshold in which devs can request readonly access before requiring approval | integer
+| gatekeeper.approvalThreshold.dev.readonly_confidential.<environment>| The threshold in which devs can request readonly access before requiring approval | integer
 | gatekeeper.approvalThreshold.dev.datafix.<environment>| The threshold in which devs can request datafix access before requiring approval | integer
 | gatekeeper.approvalThreshold.dev.dba.<environment>| The threshold in which devs can request dba access before requiring approval | integer
+| gatekeeper.approvalThreshold.dev.dba_confidential.<environment>| The threshold in which devs can request dba access before requiring approval | integer
 | gatekeeper.approvalThreshold.ops.readonly.<environment>| The threshold in which ops can request readonly access before requiring approval | integer
+| gatekeeper.approvalThreshold.ops.readonly_confidential.<environment>| The threshold in which ops can request readonly access before requiring approval | integer
 | gatekeeper.approvalThreshold.ops.datafix.<environment>| The threshold in which ops can request readonly access before requiring approval | integer
 | gatekeeper.approvalThreshold.ops.dba.<environment>| The threshold in which ops can request dba access before requiring approval  | integer
+| gatekeeper.approvalThreshold.ops.dba_confidential.<environment>| The threshold in which ops can request dba access before requiring approval  | integer
 | gatekeeper.approvalThreshold.dba.readonly.<environment>| The threshold in which dbas can request readonly access before requiring approval | integer
+| gatekeeper.approvalThreshold.dba.readonly_confidential.<environment>| The threshold in which dbas can request readonly access before requiring approval | integer
 | gatekeeper.approvalThreshold.dba.datafix.<environment>| The threshold in which dbas can request readonly access before requiring approval | integer
 | gatekeeper.approvalThreshold.dba.dba.<environment>| The threshold in which dbas can request readonly access before requiring approval | integer
+| gatekeeper.approvalThreshold.dba.dba_confidential.<environment>| The threshold in which dbas can request readonly access before requiring approval | integer
 | gatekeeper.overridePolicy.maxDays | The maximum amount of time a user can request temporary access for | integer
-| gatekeeper.overridePolicy.<user_role>.<db_role>.<environment> | for a given user role, db role and environment, this Overrides the maximum amount of days a user can request temporary access for | integer
+| gatekeeper.overridePolicy.overrides.<user_role>.<db_role>.<environment> | for a given user role, db role and environment, this Overrides the maximum amount of days a user can request temporary access for | integer

--- a/aws/rds/postgres_setup.sql
+++ b/aws/rds/postgres_setup.sql
@@ -20,8 +20,12 @@ alter role gatekeeper with CREATEROLE;
 create role gk_readonly;
 create role gk_dba;
 create role gk_datafix;
+create role gk_readonly_confidential;
+create fole gk_dba_confidential;
 
 --we have to grant all roles to gatekeeper for the schema query
 grant gk_readonly to gatekeeper;
 grant gk_datafix to gatekeeper;
 grant gk_dba to gatekeeper;
+grant gk_readonly_confidential to gatekeeper;
+grant gk_dba_confidential to gatekeeper;

--- a/config/rds_service_config.env
+++ b/config/rds_service_config.env
@@ -19,6 +19,11 @@ gatekeeper.approvalThreshold.dev.readonly.qa=100
 gatekeeper.approvalThreshold.dev.readonly.prod=-1
 gatekeeper.approvalThreshold.dev.readonly.test=180
 
+gatekeeper.approvalThreshold.dev.readonly_confidential.dev=50
+gatekeeper.approvalThreshold.dev.readonly_confidential.qa=20
+gatekeeper.approvalThreshold.dev.readonly_confidential.prod=-1
+gatekeeper.approvalThreshold.dev.readonly_confidential.test=100
+
 gatekeeper.approvalThreshold.dev.datafix.dev=180
 gatekeeper.approvalThreshold.dev.datafix.qa=180
 gatekeeper.approvalThreshold.dev.datafix.prod=-1
@@ -29,10 +34,20 @@ gatekeeper.approvalThreshold.dev.dba.qa=2
 gatekeeper.approvalThreshold.dev.dba.prod=-1
 gatekeeper.approvalThreshold.dev.dba.test=50
 
+gatekeeper.approvalThreshold.dev.dba_confidential.dev=-1
+gatekeeper.approvalThreshold.dev.dba_confidential.qa=-1
+gatekeeper.approvalThreshold.dev.dba_confidential.prod=-1
+gatekeeper.approvalThreshold.dev.dba_confidential.test=-1
+
 gatekeeper.approvalThreshold.ops.readonly.dev=-1
 gatekeeper.approvalThreshold.ops.readonly.qa=-1
 gatekeeper.approvalThreshold.ops.readonly.prod=180
 gatekeeper.approvalThreshold.ops.readonly.test=1
+
+gatekeeper.approvalThreshold.ops.readonly_confidential.dev=75
+gatekeeper.approvalThreshold.ops.readonly_confidential.qa=50
+gatekeeper.approvalThreshold.ops.readonly_confidential.prod=-1
+gatekeeper.approvalThreshold.ops.readonly_confidential.test=125
 
 gatekeeper.approvalThreshold.ops.datafix.dev=-1
 gatekeeper.approvalThreshold.ops.datafix.qa=-1
@@ -44,10 +59,20 @@ gatekeeper.approvalThreshold.ops.dba.qa=-1
 gatekeeper.approvalThreshold.ops.dba.prod=-1
 gatekeeper.approvalThreshold.ops.dba.test=2
 
+gatekeeper.approvalThreshold.ops.dba_confidential.dev=-1
+gatekeeper.approvalThreshold.ops.dba_confidential.qa=-1
+gatekeeper.approvalThreshold.ops.dba_confidential.prod=-1
+gatekeeper.approvalThreshold.ops.dba_confidential.test=-1
+
 gatekeeper.approvalThreshold.dba.readonly.dev=180
 gatekeeper.approvalThreshold.dba.readonly.qa=180
 gatekeeper.approvalThreshold.dba.readonly.prod=180
 gatekeeper.approvalThreshold.dba.readonly.test=180
+
+gatekeeper.approvalThreshold.dba.readonly_confidential.dev=100
+gatekeeper.approvalThreshold.dba.readonly_confidential.qa=125
+gatekeeper.approvalThreshold.dba.readonly_confidential.prod=1
+gatekeeper.approvalThreshold.dba.readonly_confidential.test=150
 
 gatekeeper.approvalThreshold.dba.datafix.dev=180
 gatekeeper.approvalThreshold.dba.datafix.qa=180
@@ -59,8 +84,13 @@ gatekeeper.approvalThreshold.dba.dba.qa=180
 gatekeeper.approvalThreshold.dba.dba.prod=-1
 gatekeeper.approvalThreshold.dba.dba.test=180
 
+gatekeeper.approvalThreshold.dba.dba_confidential.dev=180
+gatekeeper.approvalThreshold.dba.dba_confidential.qa=180
+gatekeeper.approvalThreshold.dba.dba_confidential.prod=1
+gatekeeper.approvalThreshold.dba.dba_confidential.test=100
+
 gatekeeper.overridePolicy.maxDays=180
 
-gatekeeper.overridePolicy.dev.dba.prod=7
-gatekeeper.overridePolicy.ops.dba.prod=7
-gatekeeper.overridePolicy.dba.dba.prod=7
+gatekeeper.overridePolicy.overrides.dev.dba.prod=7
+gatekeeper.overridePolicy.overrides.ops.dba.prod=7
+gatekeeper.overridePolicy.overrides.dba.dba.prod=7

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/interfaces/DBConnection.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/interfaces/DBConnection.java
@@ -72,4 +72,9 @@ public interface DBConnection {
      */
     List<DbUser> getUsers(String address) throws SQLException;
 
+    /**
+     * Connects to the DB and gets all of the available gk roles currently on the RDS instance
+     */
+    List<String> getAvailableRoles(String address) throws SQLException;
+
 }

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/model/RoleType.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/model/RoleType.java
@@ -21,7 +21,11 @@ package org.finra.gatekeeper.rds.model;
  * Domain Representation of the 3 Gatekeeper RDS Roles that get requested
  */
 public enum RoleType {
-    READONLY("readonly", "ro", "gk_readonly", "Read Only"),DATAFIX("datafix", "df", "gk_datafix", "Datafix"),DBA("dba", "dba", "gk_dba", "DBA");
+    READONLY("readonly", "ro", "gk_readonly", "Read Only"),
+    DATAFIX("datafix", "df", "gk_datafix", "Datafix"),
+    DBA("dba", "dba", "gk_dba", "DBA"),
+    READONLY_CONFIDENTIAL("readonly_confidential", "roc", "gk_readonly_confidential", "Read Only Confidential" ),
+    DBA_CONFIDENTIAL("dba_confidential", "dbac", "gk_dba_confidential", "DBA Confidential" );
 
     private String userSuffix;
     private String shortSuffix;

--- a/services/rds/src/main/java/org/finra/gatekeeper/configuration/GatekeeperOverrideProperties.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/configuration/GatekeeperOverrideProperties.java
@@ -40,18 +40,18 @@ public class GatekeeperOverrideProperties {
         return this;
     }
 
-    public GatekeeperOverrideProperties setOverrides(Map<String, Object> overrides) {
+    public GatekeeperOverrideProperties setOverrides(Map<String, Map<String, Map<String, Integer>>> overrides) {
         this.overrides = overrides;
         return this;
     }
 
-    private Map<String, Object> overrides = new HashMap<>();
+    private Map<String, Map<String, Map<String, Integer>>> overrides = new HashMap<>();
 
-    public Map<String, Object> getOverrides() {
+    public Map<String, Map<String, Map<String, Integer>>> getOverrides() {
         return overrides;
     }
 
-    private Map<String, Map<String, Integer>> getOverridePolicy(GatekeeperRdsRole role) {
+    public Map<String, Map<String, Integer>> getOverridePolicy(GatekeeperRdsRole role) {
         return (Map<String, Map<String, Integer>>)this.overrides.get(role.toString().toLowerCase());
     }
 

--- a/services/rds/src/main/java/org/finra/gatekeeper/controllers/AuthController.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/controllers/AuthController.java
@@ -3,6 +3,7 @@ package org.finra.gatekeeper.controllers;
 import org.finra.gatekeeper.common.authfilter.parser.IGatekeeperUserProfile;
 import org.finra.gatekeeper.common.services.user.model.GatekeeperUserEntry;
 import org.finra.gatekeeper.configuration.GatekeeperApprovalProperties;
+import org.finra.gatekeeper.configuration.GatekeeperOverrideProperties;
 import org.finra.gatekeeper.services.auth.GatekeeperRoleService;
 import org.finra.gatekeeper.services.auth.GatekeeperRdsRole;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,11 +25,13 @@ public class AuthController {
 
     private final GatekeeperRoleService gatekeeperRoleService;
     private final GatekeeperApprovalProperties approvalThreshold;
+    private final GatekeeperOverrideProperties gatekeeperOverrideProperties;
 
     @Autowired
-    public AuthController(GatekeeperRoleService gatekeeperRoleService, GatekeeperApprovalProperties gatekeeperApprovalProperties) {
+    public AuthController(GatekeeperRoleService gatekeeperRoleService, GatekeeperApprovalProperties gatekeeperApprovalProperties, GatekeeperOverrideProperties gatekeeperOverrideProperties) {
         this.gatekeeperRoleService = gatekeeperRoleService;
         this.approvalThreshold = gatekeeperApprovalProperties;
+        this.gatekeeperOverrideProperties = gatekeeperOverrideProperties;
 
     }
 
@@ -41,6 +44,8 @@ public class AuthController {
         GatekeeperRdsRole role = gatekeeperRoleService.getRole();
         result.put("email", user.getEmail());
         result.put("approvalThreshold", approvalThreshold.getApprovalPolicy(role));
+        result.put("maxDays", gatekeeperOverrideProperties.getMaxDays());
+        result.put("overridePolicy", gatekeeperOverrideProperties.getOverridePolicy(role));
         result.put("role", role);
         switch(role){
             case APPROVER:

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/RdsLookupService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/RdsLookupService.java
@@ -116,6 +116,7 @@ public class RdsLookupService {
 
                 String status = item.getDBInstanceStatus();
                 String dbName = item.getDBName();
+                List<String> availableRoles = null;
                 if(dbName ==null && item.getEngine().equalsIgnoreCase("postgres")){
                     dbName = item.getEngine().toLowerCase();
                 }
@@ -127,21 +128,34 @@ public class RdsLookupService {
 
                     try {
 
-                        String dbStatus = databaseConnectionService.checkDb(item.getEngine(), item.getEndpoint().getAddress() + ":" + item.getEndpoint().getPort() + "/" + dbName);
+                        String dbStatus = databaseConnectionService.checkDb(item.getEngine(), getAddress(item.getEndpoint().getAddress(),String.valueOf(item.getEndpoint().getPort()),dbName));
                         status = !dbStatus.isEmpty() ? dbStatus : status;
                     }catch(GKUnsupportedDBException e){
                         logger.error("Database Engine is not supported", e);
                         status = "DB Engine not supported";
                     }
+
+                    // get available roles for DB
+                    try {
+                        availableRoles = databaseConnectionService.getAvailableRolesForDb(item.getEngine(), getAddress(item.getEndpoint().getAddress(),String.valueOf(item.getEndpoint().getPort()),dbName));
+                        Collections.sort(availableRoles);
+                    }catch(Exception e){
+                        logger.error("Could not fetch roles available to DB", e);
+                        status = "Could not fetch roles available to DB";
+                    }
                 }
 
                 gatekeeperRDSInstances.add(new GatekeeperRDSInstance(item.getDbiResourceId(), item.getDBInstanceIdentifier(),
                         dbName != null ? dbName : "", item.getEngine(), status,
-                        item.getDBInstanceArn(), item.getEndpoint().getAddress() + ":" + item.getEndpoint().getPort(), application, enabled));
+                        item.getDBInstanceArn(), item.getEndpoint().getAddress() + ":" + item.getEndpoint().getPort(), application, availableRoles, enabled));
             }
         });
 
         return gatekeeperRDSInstances;
+    }
+
+    private String getAddress(String address, String port, String dbName){
+        return String.format("%s:%s/%s", address, port, dbName);
     }
 
     private List<GatekeeperRDSInstance> loadInstances(AWSEnvironment environment) {

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/GatekeeperRDSInstance.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/GatekeeperRDSInstance.java
@@ -19,6 +19,7 @@ package org.finra.gatekeeper.services.aws.model;
 
 import com.google.common.base.MoreObjects;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -33,9 +34,10 @@ public class GatekeeperRDSInstance {
     private String arn;
     private String endpoint;
     private String application;
+    private List<String> availableRoles;
     private boolean enabled;
 
-    public GatekeeperRDSInstance(String instanceId, String name, String dbName, String engine, String status, String arn, String endpoint, String application, Boolean enabled){
+    public GatekeeperRDSInstance(String instanceId, String name, String dbName, String engine, String status, String arn, String endpoint, String application, List<String> availableRoles, Boolean enabled){
         this.instanceId = instanceId;
         this.name = name;
         this.dbName = dbName;
@@ -44,6 +46,7 @@ public class GatekeeperRDSInstance {
         this.arn = arn;
         this.endpoint = endpoint;
         this.application = application;
+        this.availableRoles = availableRoles;
         this.enabled = enabled;
     }
 
@@ -69,6 +72,7 @@ public class GatekeeperRDSInstance {
 
     public String getApplication() { return application; }
 
+    public List<String> getAvailableRoles() { return availableRoles; }
     public Boolean getEnabled() { return enabled;}
     @Override
     public boolean equals(Object o){
@@ -89,12 +93,13 @@ public class GatekeeperRDSInstance {
                 && Objects.equals(this.arn, that.getArn())
                 && Objects.equals(this.endpoint, that.getEndpoint())
                 && Objects.equals(this.application, that.getApplication())
+                && Objects.equals(this.availableRoles, that.getAvailableRoles())
                 && Objects.equals(this.enabled, that.getEnabled());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(instanceId, name, dbName, engine, status, arn, endpoint, application, enabled);
+        return Objects.hash(instanceId, name, dbName, engine, status, arn, endpoint, application, availableRoles, enabled);
     }
 
     @Override
@@ -108,6 +113,7 @@ public class GatekeeperRDSInstance {
                 .add("ARN", arn)
                 .add("Endpoint", endpoint)
                 .add("Application", application)
+                .add("Available Roles", availableRoles)
                 .add("Enabled?", enabled)
                 .toString();
     }

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/db/DatabaseConnectionService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/db/DatabaseConnectionService.java
@@ -138,6 +138,9 @@ public class DatabaseConnectionService {
         return databaseConnectionFactory.getConnection(database.getEngine()).getUsers(getAddress(database.getEndpoint(), database.getDbName()));
     }
 
+    public List<String> getAvailableRolesForDb(String engine, String address) throws Exception {
+        return databaseConnectionFactory.getConnection(engine).getAvailableRoles(address);
+    }
     /**
      * Check to see if the users in the request exist in the databases and have some kind of dependency constraint that could cause
      * gatekeeper to fail

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/db/connections/MySQLDBConnection.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/db/connections/MySQLDBConnection.java
@@ -221,6 +221,10 @@ public class MySQLDBConnection implements DBConnection {
         return Collections.emptyList();
     }
 
+    public List<String> getAvailableRoles(String address) throws SQLException{
+        return Arrays.asList("gk_readonly", "gk_datafix", "gk_dba");
+    }
+
     private class MySqlStatement implements StatementCallback<Boolean>{
         private String sql;
 

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/db/connections/PostgresDBConnection.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/db/connections/PostgresDBConnection.java
@@ -258,6 +258,21 @@ public class PostgresDBConnection implements DBConnection {
         return results;
     }
 
+    public List<String> getAvailableRoles(String address) throws SQLException{
+        PGPoolingDataSource dataSource = connect(address);
+        JdbcTemplate conn = new JdbcTemplate(dataSource);
+        List<String> results;
+        logger.info("Getting available roles for " + address);
+        try {
+            results = conn.queryForList("select rolname from pg_catalog.pg_roles where rolname like 'gk_%' and rolcanlogin = false", String.class);
+        } catch (Exception ex) {
+            logger.error("Could not retrieve list of roles for database " + address, ex);
+            throw ex;
+        }
+        dataSource.close();
+        return results;
+    }
+
     private boolean revokeUser(JdbcTemplate conn, String user){
         return conn.execute("DROP USER IF EXISTS " + user, new PostgresCallableStatementExecutor());
 

--- a/ui/app/component/rds/GatekeeperRdsController.js
+++ b/ui/app/component/rds/GatekeeperRdsController.js
@@ -97,6 +97,8 @@ class GatekeeperRdsController extends GatekeeperController{
             vm.global.userInfo.userId = data.userId;
             vm.global.userInfo.user = data.name;
             vm.global.userInfo.email = data.email;
+            vm.global.rdsOverridePolicy = data.overridePolicy;
+            vm.global.rdsMaxDays = data.maxDays;
             if([ROLES.approver, ROLES.support].indexOf(data.role) === -1 && data.memberships.length === 0 ){
                 vm.global.userInfo.role = ROLES.unauthorized;
             }else{

--- a/ui/app/component/rds/index.js
+++ b/ui/app/component/rds/index.js
@@ -21,7 +21,7 @@ import gkRdsCtrl from './GatekeeperRdsController';
 import util from '../shared/generic/DirectiveUtils';
 import Directive from '../shared/generic/BaseDirective';
 import GkRdsSearch from './selfservice/GkRdsSearch';
-
+import GkRdsCheckbox from './selfservice/GkRdsCheckbox';
 import gkRdsSelfServiceCtrl from './selfservice/RdsSelfServiceController';
 import gkRdsSchemaDialogController from './selfservice/RdsSchemaDialogController';
 import gkRdsRequestCtrl from './request/RdsRequestController';
@@ -36,6 +36,7 @@ gateKeeperModule.controller('gkRdsController', gkRdsCtrl)
     .controller('gkRdsRequestHistoryController', gkRdsHistoryRequestCtrl)
     .controller('gkRdsSchemaDialogController', gkRdsSchemaDialogController)
     .controller('gkRdsAdminController', gkRdsAdminCtrl)
+    .directive('gatekeeperRoleCheckbox', util.newDirective(new GkRdsCheckbox(require('./selfservice/template/gatekeeperRoleCheckbox.tpl.html'))))
     .directive('gatekeeperRdsComponent',   util.newDirective(new GkRdsSearch(require('./selfservice/template/gatekeeperAWSRdsComponent.tpl.html'))))
     .directive('gatekeeperRdsGrantComponent', util.newDirective(new Directive(require('./selfservice/template/gatekeeperRdsGrantComponent.tpl.html'))));
 

--- a/ui/app/component/rds/selfservice/GkRdsCheckbox.js
+++ b/ui/app/component/rds/selfservice/GkRdsCheckbox.js
@@ -1,0 +1,71 @@
+/*
+ *
+ * Copyright 2018. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Directive from '../../shared/generic/BaseDirective';
+
+/**
+ * A simple wrapper around md-data-table
+ */
+
+class GkRdsCheckbox extends Directive{
+    constructor(template){
+        super(template);
+        this.scope = {
+            formObj: '=',
+            formAttr: '@',
+            label: '@',
+            disableFn: '=',
+        };
+        this.transclude = true;
+        this.controllerAs="ctrl";
+    }
+
+    controller($scope){
+        let vm = this;
+
+        if(!$scope.formObj){
+            $scope.formObj = {};
+        }
+
+        vm.updateForm = (value) => {
+            $scope.formObj[$scope.formAttr] = value;
+        };
+
+        /**
+         * Check whether to disable a checkbox. If a checkbox should be disabled then it will clear the value inside that checkbox as well.
+         * @returns {*}
+         */
+        vm.disable = () => {
+            if(!$scope.formObj){
+                return true;
+            }
+
+            let disabled = $scope.disableFn();
+            if(disabled) {
+                $scope.value = false;
+                $scope.formObj[$scope.formAttr] = false;
+            }
+            return disabled;
+        };
+    }
+
+}
+
+export default GkRdsCheckbox;
+
+
+

--- a/ui/app/component/rds/selfservice/GkRdsSearch.js
+++ b/ui/app/component/rds/selfservice/GkRdsSearch.js
@@ -89,7 +89,7 @@ class GkRdsSearch extends Directive{
                 {dataType: 'string', display: 'Instance Name', value: 'name'},
                 {dataType: 'string', display: 'Database Name', value: 'dbName'},
                 {dataType: 'string', display: 'Engine',        value: 'engine'},
-                {dataType: 'string', display: 'Instance ID',   value: 'instanceId'},
+                {dataType: 'string', display: 'Available Roles',   value: 'roles'},
                 {dataType: 'string', display: 'Status',        value: 'status'}
             ],
             data: $scope.data,
@@ -120,6 +120,16 @@ class GkRdsSearch extends Directive{
                     });
 
                 vm.awsTable.promise.then((response) => {
+                    console.info(response);
+                    response.data.forEach((item) => {
+                        let roles = '';
+                        if(item.availableRoles !== null) {
+                            item.availableRoles.forEach((role, index) => {
+                                roles += role.substr(3).replace('_confidential', ' (c)') + (index < item.availableRoles.length - 1 ? ' | ' : '');
+                            });
+                        }
+                        item.roles = roles;
+                    });
                     vm.awsTable.data.push.apply(vm.awsTable.data, response.data);
                 }).catch((error) =>{
                     vm.error.aws = error;

--- a/ui/app/component/rds/selfservice/template/gatekeeperRdsGrantComponent.tpl.html
+++ b/ui/app/component/rds/selfservice/template/gatekeeperRdsGrantComponent.tpl.html
@@ -44,15 +44,7 @@
         <h3 class=".md-display-3">With the following roles</h3>
         <form name="gkSelfServiceCtrl.forms.grantForm" layout="column">
             <div layout="row">
-                <md-checkbox ng-model="gkSelfServiceCtrl.forms.grantForm.selectedRoles.readonly" aria-label="Read Only">
-                    Read Only
-                </md-checkbox>
-                <md-checkbox ng-model="gkSelfServiceCtrl.forms.grantForm.selectedRoles.datafix" aria-label="Datafix">
-                    Datafix
-                </md-checkbox>
-                <md-checkbox ng-model="gkSelfServiceCtrl.forms.grantForm.selectedRoles.dba" aria-label="DBA">
-                    DBA
-                </md-checkbox>
+                <gatekeeper-role-checkbox  ng-repeat="role in gkSelfServiceCtrl.roles" form-obj="gkSelfServiceCtrl.forms.grantForm.selectedRoles" form-attr="{{ role.model }}" label="{{ role.label }}" disable-fn="role.disableFn"></gatekeeper-role-checkbox>
             </div>
             <div layout="row">
                 <p  layout-align="end center" layout="column" class="md-title" flex="initial">Grant Access for</p>

--- a/ui/app/component/rds/selfservice/template/gatekeeperRoleCheckbox.tpl.html
+++ b/ui/app/component/rds/selfservice/template/gatekeeperRoleCheckbox.tpl.html
@@ -1,0 +1,20 @@
+<!--
+  ~
+  ~ Copyright 2018. Gatekeeper Contributors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<md-checkbox class="gk-role-checkbox" ng-change="ctrl.updateForm(value)" ng-model="value" aria-label="{{ label }}" ng-init="formValue = false" ng-disabled="ctrl.disable()">
+    {{ label }}
+</md-checkbox>

--- a/ui/app/css/main.css
+++ b/ui/app/css/main.css
@@ -116,3 +116,7 @@ md-select md-select-value span:not(.md-select-icon):after {
 .gk-user-fill {
     height:68px
 }
+
+.gk-role-checkbox {
+    padding-right: 15px;
+}

--- a/ui/test/unit/specs/rdsselfservice.component.spec.js
+++ b/ui/test/unit/specs/rdsselfservice.component.spec.js
@@ -1,0 +1,336 @@
+/*
+ *
+ * Copyright 2018. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import AccountDataService from '../../../app/component/shared/AccountDataService';
+import RdsGrantDataService from '../../../app/component/shared/RdsGrantDataService';
+
+//Controllers
+import md from 'angular-material';
+import router from 'angular-ui-router';
+import RdsSelfServiceController from '../../../app/component/rds/selfservice/RdsSelfServiceController';
+
+
+describe('GateKeeper RDS SelfService component', function () {
+
+    let $http, $state, $mdDialog, $mdToast, scope, controller;
+
+    beforeEach(angular.mock.module(md, router));
+
+    beforeEach(inject(function($rootScope, _$state_, _$http_,_$mdDialog_,_$mdToast_){
+        scope = $rootScope.$new();
+        $state =_$state_;
+        $http = _$http_;
+        $mdDialog = _$mdDialog_;
+        $mdToast = _$mdToast_;
+        $state.current.name = 'gatekeeper.rds.admin';
+    }));
+
+    //mock all this stuff out.
+    let $q, $rootScope, $httpBackend;
+    let gkAccountService, gkRdsGrantService;
+
+    describe('RdsSelfServiceController', function(){
+        beforeEach(inject(function(_$q_, _$rootScope_, _$httpBackend_){
+            $q = _$q_;
+            $rootScope = _$rootScope_;
+            $httpBackend = _$httpBackend_;
+
+            gkRdsGrantService = new RdsGrantDataService($http, $state);
+            gkAccountService = new AccountDataService($http, $state);
+
+        }));
+
+        let testInit = (happy) => {
+            let deferred = $q.defer();
+            spyOn(gkAccountService, 'fetch').and.returnValue(deferred.promise);
+            let resp = {data:['stuff']};
+
+
+            $rootScope.userInfo = {
+                role: 'DEV',
+                userId:'testId',
+                user:'test',
+                email:'test@email.com',
+                memberships: {
+                    APP: ['DEV', 'QA'],
+                    APP2: ['DEV']
+                }
+            };
+
+            $rootScope.rdsMaxDays = 100;
+            $rootScope.rdsOverridePolicy = {
+                datafix: {
+                    prod: 10
+                },
+                dba: {
+                    prod: 5
+                },
+                dba_confidential: {
+                    prod: 2
+                },
+                readonly_confidential: {
+                    prod: 4
+                }
+            };
+
+            $rootScope.userInfo.approvalThreshold = {
+                datafix: {
+                    dev: 99,
+                    qa: 50,
+                    prod: 1
+                },
+                dba: {
+                    dev: 76,
+                    qa: 50,
+                    prod: 1
+                },
+                readonly: {
+                    dev: 65,
+                    qa: 50,
+                    prod: 1
+                },
+                readonly_confidential: {
+                    dev: 99,
+                    qa: 50,
+                    prod: 1
+                },
+                dba_confidential: {
+                    dev: 99,
+                    qa: 50,
+                    prod: 1
+                }
+            };
+
+
+            if(happy) {
+                deferred.resolve(resp);
+            }else{
+				
+                deferred.reject(resp);
+            }
+
+            controller = new RdsSelfServiceController($mdDialog, $mdToast, gkAccountService, gkRdsGrantService, scope, $state, $rootScope);
+            controller.forms.awsInstanceForm = {
+                selectedAccount: {},
+            };
+            controller.forms.grantForm = {
+                selectedRoles: {},
+            };
+        };
+
+        it('Should Initialize properly', function(){
+            testInit();
+        });
+
+        describe('Test disableRoleCheckbox() method', () => {
+            beforeEach(() => {
+                testInit();
+            });
+
+            it('should disable if all dbs do not contain the role', () => {
+                controller.forms.awsInstanceForm.selectedAccount.sdlc = 'dev';
+                controller.selectedItems = [
+                    {
+                        application: 'APP',
+                        availableRoles: ['gk_readonly', 'gk_dba', 'gk_datafix']
+                    },
+                    {
+                        application: 'APP2',
+                        availableRoles: ['gk_readonly', 'gk_dba', 'gk_datafix', 'gk_readonly_confidential', 'gk_dba_confidential']
+                    },
+                ];
+                controller.forms.grantForm.selectedRoles = {
+                    datafix: true,
+                    readonly: false
+                };
+
+                let gkReadOnlyConfidentialDisableFn = controller.disableRoleCheckbox('gk_readonly_confidential');
+
+                let result = gkReadOnlyConfidentialDisableFn();
+                expect(result).toBeTruthy();
+
+            });
+
+            it('should enable if both dbs have the role', () => {
+                controller.forms.awsInstanceForm.selectedAccount.sdlc = 'dev';
+                controller.selectedItems = [
+                    {
+                        application: 'APP',
+                        availableRoles: ['gk_readonly', 'gk_dba', 'gk_datafix']
+                    },
+                    {
+                        application: 'APP2',
+                        availableRoles: ['gk_readonly', 'gk_dba', 'gk_datafix', 'gk_readonly_confidential', 'gk_dba_confidential']
+                    },
+                ];
+                controller.forms.grantForm.selectedRoles = {
+                    datafix: true,
+                    readonly: false
+                };
+
+                let gkReadOnlyConfidentialDisableFn = controller.disableRoleCheckbox('gk_readonly');
+
+                let result = gkReadOnlyConfidentialDisableFn();
+                expect(result).toBeFalsy();
+
+            });
+
+            it('should disable if no items are selected', () => {
+                controller.forms.awsInstanceForm.selectedAccount.sdlc = 'dev';
+                controller.selectedItems = [
+
+                ];
+                controller.forms.grantForm.selectedRoles = {
+                    datafix: true,
+                    readonly: false
+                };
+
+                let gkReadOnlyConfidentialDisableFn = controller.disableRoleCheckbox('gk_readonly');
+
+                let result = gkReadOnlyConfidentialDisableFn();
+                expect(result).toBeTruthy();
+
+            });
+        });
+
+        describe('Test getApprovalBounds()', ()=> {
+            beforeEach(() => {
+                testInit();
+            });
+
+            it('should return maximum days if the user is an approver', () => {
+              $rootScope.userInfo.role = 'APPROVER';
+              let bound = controller.getApprovalBounds();
+              expect(bound).toEqual(100);
+            });
+
+            it('should return specific days if the user is a non-approver and has the same sdlc/application permissions', () => {
+                controller.forms.awsInstanceForm.selectedAccount.sdlc = 'dev';
+                controller.selectedItems = [
+                    {
+                        application: 'APP'
+                    },
+                    {
+                        application: 'APP2'
+                    },
+                ];
+                controller.forms.grantForm.selectedRoles = {
+                    datafix: true,
+                    readonly: false
+                };
+                let bound = controller.getApprovalBounds();
+                expect(bound).toEqual(99);
+
+                controller.forms.grantForm.selectedRoles = {
+                    datafix: false,
+                    readonly: true
+                };
+                bound = controller.getApprovalBounds();
+                expect(bound).toEqual(65);
+
+            });
+
+            it('should return -1 if the user is a does not have the correct application membership', () => {
+                controller.forms.awsInstanceForm.selectedAccount.sdlc = 'dev';
+                controller.selectedItems = [
+                    {
+                        application: 'APP'
+                    },
+                    {
+                        application: 'APP3'
+                    },
+                ];
+                controller.forms.grantForm.selectedRoles = {
+                    readonly: true
+                };
+
+                let bound = controller.getApprovalBounds();
+                expect(bound).toEqual(-1);
+
+            });
+
+
+            it('should return -1 if the user is a does not have the correct SDLC membership', () => {
+                controller.forms.awsInstanceForm.selectedAccount.sdlc = 'prod';
+                controller.selectedItems = [
+                    {
+                        application: 'APP'
+                    },
+                ];
+                controller.forms.grantForm.selectedRoles = {
+                    readonly: true
+                };
+
+                let bound = controller.getApprovalBounds();
+                expect(bound).toEqual(-1);
+
+            });
+
+        });
+
+        describe('Test getMaximumDays()', ()=> {
+            beforeEach(() => {
+                testInit();
+            });
+
+            it('Should default to maximum days if no override for a given role is found', () => {
+               controller.forms.awsInstanceForm.selectedAccount = {
+                   sdlc: 'dev'
+               };
+
+               controller.forms.grantForm.selectedRoles = {
+                   readonly: true
+               };
+
+               let max = controller.getMaximumDays();
+
+               expect(max).toEqual(100);
+           });
+
+            it('Should be set to 10 if prod sdlc and datafix role is selected', () => {
+                controller.forms.awsInstanceForm.selectedAccount = {
+                    sdlc: 'prod'
+                };
+
+                controller.forms.grantForm.selectedRoles = {
+                    datafix: true,
+                    readonly: false
+                };
+
+                let max = controller.getMaximumDays();
+
+                expect(max).toEqual(10);
+            });
+
+            it('Should be set to 4 if prod sdlc and datafix + readonly_confidential role is selected', () => {
+                controller.forms.awsInstanceForm.selectedAccount = {
+                    sdlc: 'prod'
+                };
+
+                controller.forms.grantForm.selectedRoles = {
+                    datafix: true,
+                    readonly_confidential: true,
+                    readonly: true
+                };
+
+                let max = controller.getMaximumDays();
+
+                expect(max).toEqual(4);
+            });
+
+        });
+    });
+});


### PR DESCRIPTION
This PR updates the gatekeeper RDS application to be able to support 2 new roles: Readonly confidential and DBA confidential 