### PR TITLE
Address an issue where database instance data was not being properly re-cached

### DIFF
--- a/services/rds/src/main/java/org/finra/gatekeeper/services/db/connections/PostgresDBConnection.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/db/connections/PostgresDBConnection.java
@@ -268,8 +268,9 @@ public class PostgresDBConnection implements DBConnection {
         } catch (Exception ex) {
             logger.error("Could not retrieve list of roles for database " + address, ex);
             throw ex;
+        }finally {
+            dataSource.close();
         }
-        dataSource.close();
         return results;
     }
 


### PR DESCRIPTION
When Gatekeeper could not successfully look up RDS roles for a user it was not properly handling the closing of a Postgres connection. This led to the application failing to properly re-cache the available instances, as a fallback the application returns the old cached value. 

This fix wraps a finally block around the call to close the connection so that the connection is always closed.