### PR TITLE
Overhauls to RDS Instance Search

### DIFF
--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/RdsLookupService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/RdsLookupService.java
@@ -99,7 +99,7 @@ public class RdsLookupService {
                         });
 
                 String status = item.getDBInstanceStatus();
-                String dbName = item.getEngine().equalsIgnoreCase("postgres") ? "postgres" : item.getDBName();
+                String dbName = item.getDBName();
                 Integer port = item.getEndpoint().getPort();
                 List<String> availableRoles = null;
 

--- a/ui/app/component/rds/selfservice/GkRdsSearch.js
+++ b/ui/app/component/rds/selfservice/GkRdsSearch.js
@@ -87,7 +87,6 @@ class GkRdsSearch extends Directive{
             onDeselect: $scope.onDeselectFn,
             headers: [
                 {dataType: 'string', display: 'Instance Name', value: 'name'},
-                {dataType: 'string', display: 'Database Name', value: 'dbName'},
                 {dataType: 'string', display: 'Engine',        value: 'engine'},
                 {dataType: 'string', display: 'Available Roles',   value: 'roles'},
                 {dataType: 'string', display: 'Status',        value: 'status'}

--- a/ui/app/component/rds/selfservice/RdsSchemaDialogController.js
+++ b/ui/app/component/rds/selfservice/RdsSchemaDialogController.js
@@ -34,7 +34,7 @@ class RdsSchemaDialogController {
         this[DIALOG] = $mdDialog;
 
         vm.fetched = false;
-        vm.schemaPromise = gkSchemaService.search({account:account.alias, region: region.name, instanceId: database.instanceId})
+        vm.schemaPromise = gkSchemaService.search({account:account.alias, region: region.name, instanceId: database.name});
         vm.schemaPromise.then((response) => {
             vm.schemas = response.data;
             vm.fetched = true;

--- a/ui/app/component/rds/selfservice/template/gatekeeperAWSRdsComponent.tpl.html
+++ b/ui/app/component/rds/selfservice/template/gatekeeperAWSRdsComponent.tpl.html
@@ -38,7 +38,7 @@
             <div layout="column">
                 <md-input-container class="md-block" md-no-float>
                     <label>Search RDS</label>
-                    <input id="gkInputAws" type="text" ng-model="ctrl.forms.awsInstanceForm.searchText" md-maxlength="30" required md-no-asterisk>
+                    <input id="gkInputAws" type="text" ng-model="ctrl.forms.awsInstanceForm.searchText" md-maxlength="30" required md-no-asterisk disallow-spaces>
                 </md-input-container>
             </div>
             <div layout="column" layout-align="center center">

--- a/ui/app/component/shared/DisallowSpaces.js
+++ b/ui/app/component/shared/DisallowSpaces.js
@@ -19,10 +19,6 @@ import Directive from '../shared/generic/BaseDirective';
 import $ from 'jquery';
 /**
  * Navigation directive
- *
- * @returns {{}}
- *
- * TODO: may need to do some fine tuning with this one.
  */
 
 class DisallowSpaces extends Directive {

--- a/ui/app/component/shared/DisallowSpaces.js
+++ b/ui/app/component/shared/DisallowSpaces.js
@@ -1,0 +1,44 @@
+/*
+ *
+ * Copyright 2018. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Directive from '../shared/generic/BaseDirective';
+import $ from 'jquery';
+/**
+ * Navigation directive
+ *
+ * @returns {{}}
+ *
+ * TODO: may need to do some fine tuning with this one.
+ */
+
+class DisallowSpaces extends Directive {
+    constructor(template){
+        super(template);
+        this.restrict = 'A';
+
+        this.controllerAs = 'gkNavCtrl';
+    }
+
+    link($scope, $element) {
+        $element.bind('input', function() {
+
+            $(this).val($(this).val().replace(/ /g, ''));
+        });
+    }
+}
+
+export default DisallowSpaces;

--- a/ui/app/component/shared/index.js
+++ b/ui/app/component/shared/index.js
@@ -17,7 +17,7 @@
 
 import md from 'angular-material';
 import table from 'angular-material-data-table';
-import Directive from './generic/BaseDirective'
+import Directive from './generic/BaseDirective';
 import ADDataService from './ADDataService';
 import AWSDataService from './AWSDataService';
 import RDSDataService from './RDSDataService';
@@ -30,6 +30,7 @@ import RoleDataService from './RoleDataService';
 import RequestDataService from './RequestDataService';
 import SchemaDataService from './SchemaDataService';
 import GkNavBar from './GkNavBar';
+import DisallowSpaces from './DisallowSpaces';
 import util from './generic/DirectiveUtils';
 
 import gkSSCtrl from './selfservice/GatekeeperSelfServiceController';
@@ -47,6 +48,7 @@ var gkUtil = angular.module('gatekeeper-util', [md, table])
     .service('gkRequestService', RequestDataService)
     .service('gkSchemaService', SchemaDataService)
     .controller('gkSelfServiceController', gkSSCtrl)
+    .directive('disallowSpaces', util.newDirective(new DisallowSpaces()))
     .directive('gatekeeperUserComponent',  util.newDirective(new Directive(require('./selfservice/template/gatekeeperADComponent.tpl.html'))))
     .directive('gkNavBar', util.newDirective(new GkNavBar(require('./template/gkNavBar.tpl.html'))));
 


### PR DESCRIPTION
- Re-factored the DB lookup to be per user, calls were too slow for s…ome users who were unlucky to catch it in the middle of re-caching, the app will only look up databases that match the user's search string.
- Enhanced the RDS lookup to Identify the assigned SSL port from an oracle instance's option group.
- RDS instances which are read-only replicas will now be disabled (GK can't create users directly on the instance due to the nature of the instance)
- Also updated the UI to not allow any spaces in the search box for the RDS instances. There are no spaces in RDS instance identifiers so the search shouldnt contain spaces either.
- GK will now always connect to postgres database on postgres RDS instances