### PR TITLE
Fixes an issue where the wrong ports are being used for oracle dbs

### DIFF
--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/RdsLookupService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/RdsLookupService.java
@@ -163,7 +163,7 @@ public class RdsLookupService {
 
                 gatekeeperRDSInstances.add(new GatekeeperRDSInstance(item.getDbiResourceId(), item.getDBInstanceIdentifier(),
                         dbName != null ? dbName : "", item.getEngine(), status,
-                        item.getDBInstanceArn(), item.getEndpoint().getAddress() + ":" + item.getEndpoint().getPort(), application, availableRoles, enabled));
+                        item.getDBInstanceArn(), item.getEndpoint().getAddress() + ":" + port, application, availableRoles, enabled));
             }
         });
 


### PR DESCRIPTION
Discovered an issue during testing where the port was not getting set in the AwsRdsInstance object correctly for oracle instances.