### PR TITLE
Update Emails with Ticket ID / Contact info for approvers

### DIFF
--- a/services/ec2/src/main/java/org/finra/gatekeeper/services/email/wrappers/EmailServiceWrapper.java
+++ b/services/ec2/src/main/java/org/finra/gatekeeper/services/email/wrappers/EmailServiceWrapper.java
@@ -16,7 +16,11 @@
 
 package org.finra.gatekeeper.services.email.wrappers;
 
+import org.finra.gatekeeper.GatekeeperCommonConfig;
+import org.finra.gatekeeper.common.properties.GatekeeperSharedProperties;
+import org.finra.gatekeeper.configuration.GatekeeperConfig;
 import org.finra.gatekeeper.configuration.properties.GatekeeperEmailProperties;
+import org.finra.gatekeeper.configuration.properties.GatekeeperProperties;
 import org.finra.gatekeeper.services.accessrequest.model.AWSInstance;
 import org.finra.gatekeeper.services.accessrequest.model.AccessRequest;
 import org.finra.gatekeeper.services.accessrequest.model.User;
@@ -71,6 +75,7 @@ public class EmailServiceWrapper {
             Map<String, Object> params = new HashMap<>();
             params.put("request", request);
             params.put("user", user);
+            params.put("approverDL", emailProperties.getApproverEmails());
             if(other != null){
                 other.forEach((k, v) -> params.put(k.toString(), v));
             }
@@ -89,7 +94,7 @@ public class EmailServiceWrapper {
      */
     public void notifyAdmins(AccessRequest request){
         logger.info("Notify the admins of: " + request);
-        emailHelper(emailProperties.getApproverEmails(), null, "GATEKEEPER: Access Requested", "accessRequested", request);
+        emailHelper(emailProperties.getApproverEmails(), null, String.format("GATEKEEPER: Access Requested (%s)", request.getId()), "accessRequested", request);
     }
 
     public void notifyExpired(AccessRequest request){

--- a/services/ec2/src/main/java/org/finra/gatekeeper/services/email/wrappers/EmailServiceWrapper.java
+++ b/services/ec2/src/main/java/org/finra/gatekeeper/services/email/wrappers/EmailServiceWrapper.java
@@ -16,11 +16,7 @@
 
 package org.finra.gatekeeper.services.email.wrappers;
 
-import org.finra.gatekeeper.GatekeeperCommonConfig;
-import org.finra.gatekeeper.common.properties.GatekeeperSharedProperties;
-import org.finra.gatekeeper.configuration.GatekeeperConfig;
 import org.finra.gatekeeper.configuration.properties.GatekeeperEmailProperties;
-import org.finra.gatekeeper.configuration.properties.GatekeeperProperties;
 import org.finra.gatekeeper.services.accessrequest.model.AWSInstance;
 import org.finra.gatekeeper.services.accessrequest.model.AccessRequest;
 import org.finra.gatekeeper.services.accessrequest.model.User;

--- a/services/ec2/src/main/resources/emails/accessDenied.ftl
+++ b/services/ec2/src/main/resources/emails/accessDenied.ftl
@@ -23,7 +23,10 @@
     </#if>
 </div>
 
+<div>
+    <p style="color: darkred">If you have any questions or concerns please reach out to the Gatekeeper approvers at: ${approverDL}</p>
+</div>
 
 <div><p>Thanks!</p></div>
-<div><p>The Gatekeeper Admins</p></div>
+<div><p>The Gatekeeper Admin Team</p></div>
 </html>

--- a/services/ec2/src/main/resources/emails/accessExpired.ftl
+++ b/services/ec2/src/main/resources/emails/accessExpired.ftl
@@ -10,6 +10,11 @@
     <div>
         <p>If you need more time on the box please go to Gatekeeper and request more access.</p>
     </div>
+
+    <div>
+        <p style="color: darkred">If you have any questions or concerns please reach out to the Gatekeeper approvers at: ${approverDL}</p>
+    </div>
+
     <div><p>Thanks!</p></div>
-    <div><p>The Gatekeeper Admins</p></div>
+    <div><p>The Gatekeeper Admin Team</p></div>
 </html>

--- a/services/ec2/src/main/resources/emails/accessGranted.ftl
+++ b/services/ec2/src/main/resources/emails/accessGranted.ftl
@@ -19,6 +19,7 @@
             </#if>
         </#list>
     </ul>
+
     <div>
         <p>Each user on the request will be emailed separately with their corresponding credentials.</p>
     </div>
@@ -33,6 +34,10 @@
         </#if>
     </div>
 
+    <div>
+        <p style="color: darkred">If you have any questions or concerns please reach out to the Gatekeeper approvers at: ${approverDL}</p>
+    </div>
+
     <div><p>Thanks!</p></div>
-    <div><p>The Gatekeeper Admins</p></div>
+    <div><p>The Gatekeeper Admin Team</p></div>
 </html>

--- a/services/ec2/src/main/resources/emails/accessRequested.ftl
+++ b/services/ec2/src/main/resources/emails/accessRequested.ftl
@@ -14,6 +14,16 @@
             <li><b>${instance.getIp()?has_content?string(instance.getIp(),'Unknown IP')}</b> -- ${instance.getName()?has_content?string(instance.getName(), 'Unknown')} -- ${instance.getInstanceId()}</li>
         </#list>
     </ul>
+
+    <h4>Ticket for request</h4>
+    <div>
+        <#if request.getTicketId()??>
+            <blockquote>${request.getTicketId()?has_content?string(request.getTicketId()!?replace('\n', '<br>'),'No ticket was provided')}</blockquote>
+        <#else>
+            <blockquote>No ticket was provided</blockquote>
+        </#if>
+    </div>
+
     <h4>Reason for request</h4>
     <div>
         <#if request.getRequestReason()??>
@@ -24,8 +34,9 @@
     </div>
 
     <div>
-        <p>Please review and action this request on the gatekeeper app.</p>
+        <p style="color: darkred">If you have any questions or concerns please reach out to the Gatekeeper approvers at: ${approverDL}</p>
     </div>
+
     <div><p>Thanks!</p></div>
-    <div><p>The Gatekeeper Admins</p></div>
+    <div><p>The Gatekeeper Admin Team</p></div>
 </html>

--- a/services/ec2/src/main/resources/emails/manualRemoval.ftl
+++ b/services/ec2/src/main/resources/emails/manualRemoval.ftl
@@ -19,5 +19,5 @@
         <p>Can somebody please investigate the following instances and determine whether manual removal of access is needed for each user?</p>
     </div>
     <div><p>Thanks!</p></div>
-    <div><p>The Gatekeeper Admins</p></div>
+    <div><p>The Gatekeeper Admin Team</p></div>
 </html>

--- a/services/ec2/src/main/resources/emails/processCancelled.ftl
+++ b/services/ec2/src/main/resources/emails/processCancelled.ftl
@@ -15,7 +15,5 @@
     <div>
         <p>Thanks!</p>
     </div>
-    <div>
-        <p>The Gatekeeper Admins</p>
-    </div>
+    <div><p>The Gatekeeper Admin Team</p></div>
 </html>

--- a/services/ec2/src/main/resources/emails/requestCanceled.ftl
+++ b/services/ec2/src/main/resources/emails/requestCanceled.ftl
@@ -17,6 +17,11 @@
     <div>
         <p>No further action is required.</p>
     </div>
+
+    <div>
+        <p style="color: darkred">If you have any questions or concerns please reach out to the Gatekeeper approvers at: ${approverDL}</p>
+    </div>
+
     <div><p>Thanks!</p></div>
-    <div><p>The Gatekeeper Admins</p></div>
+    <div><p>The Gatekeeper Admin Team</p></div>
 </html>

--- a/services/ec2/src/test/java/org/finra/gatekeeper/services/mail/EmailServiceWrapperTest.java
+++ b/services/ec2/src/test/java/org/finra/gatekeeper/services/mail/EmailServiceWrapperTest.java
@@ -69,6 +69,13 @@ public class EmailServiceWrapperTest {
     @Mock
     private AWSInstance instance;
 
+    private String testUserEmail = "TestUser@company.com";
+    private String testUserId = "testuser";
+    private String approverEmail = "GKApprover@company.com";
+    private String fromEmail = "UNIT_FROM@company.com";
+    private String teamEmail = "DL-UNIT_TEAM@company.com";
+    private String opsEmail = "GKOps@company.com";
+    private String requestEmail = "Request@company.com";
 
     @Before
     public void initMocks() throws Exception {
@@ -77,8 +84,8 @@ public class EmailServiceWrapperTest {
         when(emailService.sendEmail(anyString(),anyString(),anyString(),anyString(),anyString(),anyMap())).thenReturn(null);
 
         //A mock user
-        when(testUser.getEmail()).thenReturn("TestUser@finra.org");
-        when(testUser.getUserId()).thenReturn("Test User");
+        when(testUser.getEmail()).thenReturn(testUserEmail);
+        when(testUser.getUserId()).thenReturn(testUserId);
 
         //The mock request
         List<User> users = new ArrayList<User>();
@@ -86,7 +93,7 @@ public class EmailServiceWrapperTest {
         when(request.getUsers()).thenReturn(users);
         when(request.getId()).thenReturn(125L);
         when(request.getAccount()).thenReturn("TEP");
-        when(request.getRequestorEmail()).thenReturn("Request@finra.org");
+        when(request.getRequestorEmail()).thenReturn(requestEmail);
         List<AWSInstance> instances = new ArrayList<AWSInstance>();
 
         when(instance.getIp()).thenReturn("127.0.0.1");
@@ -94,10 +101,10 @@ public class EmailServiceWrapperTest {
         when(request.getInstances()).thenReturn(instances);
 
         //Setting up the spring values
-        when(emailProperties.getApproverEmails()).thenReturn("DL-ProductivityEng@finra.org");
-        when(emailProperties.getFrom()).thenReturn("UNIT_FROM@finra.org");
-        when(emailProperties.getTeam()).thenReturn("DL-UNIT_TEAM@finra.org");
-        when(emailProperties.getOpsEmails()).thenReturn("DL-ProductivityOps@finra.org");
+        when(emailProperties.getApproverEmails()).thenReturn(approverEmail);
+        when(emailProperties.getFrom()).thenReturn(fromEmail);
+        when(emailProperties.getTeam()).thenReturn(teamEmail);
+        when(emailProperties.getOpsEmails()).thenReturn(opsEmail);
     }
 
 
@@ -117,7 +124,7 @@ public class EmailServiceWrapperTest {
         param.put("stacktrace", constructStackTrace(exception));
 
         mailServiceWrapper.notifyAdminsOfFailure(request, exception);
-        verify(emailService, times(1)).sendEmailWithAttachment("DL-UNIT_TEAM@finra.org", "UNIT_FROM@finra.org", null, "Failure executing process", "failure", contentMap, "Exception.txt", "exception", param, "text/plain");
+        verify(emailService, times(1)).sendEmailWithAttachment(teamEmail, fromEmail, null, "Failure executing process", "failure", contentMap, "Exception.txt", "exception", param, "text/plain");
 
 
 
@@ -148,8 +155,9 @@ public class EmailServiceWrapperTest {
         param.put("privatekey", privateKeyString);
 
         mailServiceWrapper.notifyOfCredentials(request, testUser, privateKeyString,createStatus);
-        verify(emailService, times(1)).sendEmailWithAttachment(testUser.getEmail(), "UNIT_FROM@finra.org", null, "Access Request " + request.getId() + " - Your temporary credential", "credentials", contentMap, "credential.pem", "privatekey", param, "application/x-pem-file");
-        verify(emailService, times(1)).sendEmail("TestUser@finra.org", "UNIT_FROM@finra.org", null, "Access Request " + request.getId() + " - Your temporary username", "username", contentMap);
+        verify(emailService, times(1)).sendEmailWithAttachment(testUser.getEmail(), fromEmail, null, "Access Request " + request.getId() + " - Your temporary credential", "credentials", contentMap, "credential.pem", "privatekey", param, "application/x-pem-file");
+        contentMap.put("approverDL", approverEmail);
+        verify(emailService, times(1)).sendEmail(testUserEmail, fromEmail, null, "Access Request " + request.getId() + " - Your temporary username", "username", contentMap);
 
     }
 
@@ -163,8 +171,9 @@ public class EmailServiceWrapperTest {
         Map<String, Object> contentMap = new HashMap<String, Object>();
         contentMap.put("request", request);
         contentMap.put("user", null);
+        contentMap.put("approverDL", approverEmail);
         mailServiceWrapper.notifyAdmins(request);
-        verify(emailService, times(1)).sendEmail("DL-ProductivityEng@finra.org", "UNIT_FROM@finra.org", null, "GATEKEEPER: Access Requested", "accessRequested", contentMap);
+        verify(emailService, times(1)).sendEmail(approverEmail, fromEmail, null, "GATEKEEPER: Access Requested ("+request.getId()+")", "accessRequested", contentMap);
     }
 
     /**
@@ -176,8 +185,9 @@ public class EmailServiceWrapperTest {
         Map<String, Object> contentMap = new HashMap<String, Object>();
         contentMap.put("request", request);
         contentMap.put("user", null);
+        contentMap.put("approverDL", approverEmail);
         mailServiceWrapper.notifyExpired(request);
-        verify(emailService, times(1)).sendEmail(testUser.getEmail(), "UNIT_FROM@finra.org", null, "Your Access has expired", "accessExpired", contentMap);
+        verify(emailService, times(1)).sendEmail(testUser.getEmail(), fromEmail, null, "Your Access has expired", "accessExpired", contentMap);
     }
 
     /**
@@ -190,8 +200,9 @@ public class EmailServiceWrapperTest {
         contentMap.put("request", request);
         contentMap.put("offlineInstances", Arrays.asList(new AWSInstance[]{instance}));
         contentMap.put("user", null);
+        contentMap.put("approverDL", approverEmail);
         mailServiceWrapper.notifyOps(request);
-        verify(emailService, times(1)).sendEmail("DL-ProductivityOps@finra.org", "UNIT_FROM@finra.org",  "DL-UNIT_TEAM@finra.org", "GATEKEEPER: Manual revoke access for expired request", "manualRemoval", contentMap);
+        verify(emailService, times(1)).sendEmail(opsEmail, fromEmail,  teamEmail, "GATEKEEPER: Manual revoke access for expired request", "manualRemoval", contentMap);
     }
 
     /**
@@ -203,8 +214,9 @@ public class EmailServiceWrapperTest {
         Map<String, Object> contentMap = new HashMap<String, Object>();
         contentMap.put("request", request);
         contentMap.put("user", null);
+        contentMap.put("approverDL", approverEmail);
         mailServiceWrapper.notifyApproved(request);
-        verify(emailService, times(1)).sendEmail("Request@finra.org", "UNIT_FROM@finra.org", null, "Access Request 125 was granted", "accessGranted", contentMap);
+        verify(emailService, times(1)).sendEmail(requestEmail, fromEmail, null, "Access Request 125 was granted", "accessGranted", contentMap);
     }
 
     /**
@@ -216,8 +228,9 @@ public class EmailServiceWrapperTest {
         Map<String, Object> contentMap = new HashMap<String, Object>();
         contentMap.put("request", request);
         contentMap.put("user", null);
+        contentMap.put("approverDL", approverEmail);
         mailServiceWrapper.notifyCanceled(request);
-        verify(emailService, times(1)).sendEmail("DL-ProductivityEng@finra.org", "UNIT_FROM@finra.org", "Request@finra.org", "Access Request 125 was canceled", "requestCanceled", contentMap);
+        verify(emailService, times(1)).sendEmail(approverEmail, fromEmail, requestEmail, "Access Request 125 was canceled", "requestCanceled", contentMap);
     }
 
 
@@ -230,8 +243,9 @@ public class EmailServiceWrapperTest {
         Map<String, Object> contentMap = new HashMap<String, Object>();
         contentMap.put("request", request);
         contentMap.put("user", null);
+        contentMap.put("approverDL", approverEmail);
         mailServiceWrapper.notifyRejected(request);
-        verify(emailService, times(1)).sendEmail("Request@finra.org", "UNIT_FROM@finra.org", null, "Access Request 125 was denied", "accessDenied", contentMap);
+        verify(emailService, times(1)).sendEmail(requestEmail, fromEmail, null, "Access Request 125 was denied", "accessDenied", contentMap);
     }
 
     private String constructStackTrace(Throwable exception) {

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/email/wrappers/EmailServiceWrapper.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/email/wrappers/EmailServiceWrapper.java
@@ -79,6 +79,8 @@ public class EmailServiceWrapper {
             Map<String, Object> params = new HashMap<>();
             params.put("request", request);
             params.put("user", user);
+            params.put("approverDL", approverEmails);
+
             if(other != null){
                 other.forEach((k, v) -> params.put(k.toString(), v));
             }
@@ -97,7 +99,7 @@ public class EmailServiceWrapper {
      */
     public void notifyAdmins(AccessRequest request){
         logger.info("Notify the admins of: " + request);
-        emailHelper(approverEmails, null, "GATEKEEPER: Access Requested", "accessRequested", request);
+        emailHelper(approverEmails, null, String.format("GATEKEEPER: Access Requested (%s)", request.getId()), "accessRequested", request);
     }
 
     public void notifyExpired(AccessRequest request){

--- a/services/rds/src/main/resources/emails/accessDenied.ftl
+++ b/services/rds/src/main/resources/emails/accessDenied.ftl
@@ -5,24 +5,27 @@
 <div><h4>Users</h4></div>
 <ul>
     <#list request.getUsers() as user>
-        <li><b>${user.getName()}</b> -- ${user.getEmail()! 'Unknown'}</li>
-    </#list>
+    <li><b>${user.getName()}</b> -- ${user.getEmail()! 'Unknown'}</li>
+</#list>
 </ul>
 <div><h4>Instances</h4></div>
 <ul>
     <#list request.getAwsRdsInstances() as db>
-        <li><b>${db.getInstanceId()}</b> -- ${db.getName()?has_content?string(db.getName(), 'Unknown')} -- ${db.getEngine()}</li>
-    </#list>
+    <li><b>${db.getInstanceId()}</b> -- ${db.getName()?has_content?string(db.getName(), 'Unknown')} -- ${db.getEngine()}</li>
+</#list>
 </ul>
 <div><h4>Reason:</h4></div>
 <div>
     <#if request.getApproverComments()??>
-        <blockquote>${request.getApproverComments()?has_content?string(request.getApproverComments()!?replace('\n', '<br>'),'No reason was provided')}</blockquote>
+    <blockquote>${request.getApproverComments()?has_content?string(request.getApproverComments()!?replace('\n', '<br>'),'No reason was provided')}</blockquote>
     <#else>
-        <blockquote>No reason was provided</blockquote>
-    </#if>
+    <blockquote>No reason was provided</blockquote>
+</#if>
 </div>
 
+<div>
+    <p style="color: darkred">If you have any questions or concerns please reach out to the Gatekeeper approvers at: ${approverDL}</p>
+</div>
 
 <div><p>Thanks!</p></div>
 <div><p>The Gatekeeper Admin Team</p></div>

--- a/services/rds/src/main/resources/emails/accessExpired.ftl
+++ b/services/rds/src/main/resources/emails/accessExpired.ftl
@@ -7,9 +7,15 @@
             <li><b>${db.getInstanceId()}</b> -- ${db.getName()?has_content?string(db.getName(), 'Unknown')} -- ${db.getEngine()}</li>
         </#list>
     </ul>
+
     <div>
         <p>If you need more time on the box please go to Gatekeeper and request more access.</p>
     </div>
+
+    <div>
+        <p style="color: darkred">If you have any questions or concerns please reach out to the Gatekeeper approvers at: ${approverDL}</p>
+    </div>
+
     <div><p>Thanks!</p></div>
     <div><p>The Gatekeeper Admin Team</p></div>
 </html>

--- a/services/rds/src/main/resources/emails/accessGranted.ftl
+++ b/services/rds/src/main/resources/emails/accessGranted.ftl
@@ -28,6 +28,10 @@
         </#if>
     </div>
 
+    <div>
+        <p style="color: darkred">If you have any questions or concerns please reach out to the Gatekeeper approvers at: ${approverDL}</p>
+    </div>
+
     <div><p>Thanks!</p></div>
     <div><p>The Gatekeeper Admin Team</p></div>
 </html>

--- a/services/rds/src/main/resources/emails/accessRequested.ftl
+++ b/services/rds/src/main/resources/emails/accessRequested.ftl
@@ -14,6 +14,16 @@
             <li><b>${db.getInstanceId()}</b> -- ${db.getName()?has_content?string(db.getName(), 'Unknown')} -- ${db.getEngine()}</li>
         </#list>
     </ul>
+
+    <h4>Ticket for request</h4>
+    <div>
+        <#if request.getTicketId()??>
+            <blockquote>${request.getTicketId()?has_content?string(request.getTicketId()!?replace('\n', '<br>'),'No ticket was provided')}</blockquote>
+        <#else>
+            <blockquote>No ticket was provided</blockquote>
+        </#if>
+    </div>
+
     <h4>Reason for request</h4>
     <div>
         <#if request.getRequestReason()??>
@@ -26,6 +36,7 @@
     <div>
         <p>Please review and action this request on the gatekeeper app.</p>
     </div>
+
     <div><p>Thanks!</p></div>
     <div><p>The Gatekeeper Admin Team</p></div>
 </html>

--- a/services/rds/src/main/resources/emails/requestCanceled.ftl
+++ b/services/rds/src/main/resources/emails/requestCanceled.ftl
@@ -17,6 +17,11 @@
     <div>
         <p>No further action is required.</p>
     </div>
+
+    <div>
+        <p style="color: darkred">If you have any questions or concerns please reach out to the Gatekeeper approvers at: ${approverDL}</p>
+    </div>
+
     <div><p>Thanks!</p></div>
     <div><p>The Gatekeeper Admin Team</p></div>
 </html>


### PR DESCRIPTION
This update does the following:

1. Adds the ticket ID to the emails that get sent to the approvers
2. Adds a message to the bottom of the granted/rejected/cancelled/expired emails that tell the users who they can email for any questions/concerns
3. The Request ID will be included when it is sent to the ops team
4. fixes to various tests

Signed-off-by: Stephen Mele <Smelecs@gmail.com>