### PR TITLE
Fix to accessRequested.eml template found while testing

### DIFF
--- a/services/ec2/src/main/resources/emails/accessRequested.ftl
+++ b/services/ec2/src/main/resources/emails/accessRequested.ftl
@@ -33,9 +33,6 @@
         </#if>
     </div>
 
-    <div>
-        <p style="color: darkred">If you have any questions or concerns please reach out to the Gatekeeper approvers at: ${approverDL}</p>
-    </div>
 
     <div><p>Thanks!</p></div>
     <div><p>The Gatekeeper Admin Team</p></div>


### PR DESCRIPTION
Removing the if you have questions line from the access requested email in ec2 service because this email is only intended for the approvers.

Signed-off-by: Stephen Mele <Smelecs@gmail.com>