### PR TITLE
Don't call getLiveRequests on Create/Revoke if topicARN doesn't get set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,11 @@ These configurations are specific to Gatekeeper RDS
 | gatekeeper.auth.devGroupsPattern | A regular expression to extract group(s) of Dev Members from ldap groups. requires one capture | string
 
 ### SNS
-Gatekeeper supports the publishing of Approval/Expiration events to an SNS topic, this can be useful if you have other applications that need to react to an event from the gatekeeper service
+Gatekeeper supports the publishing of Approval/Expiration events to an SNS topic, this can be useful if you have other applications that need to react to an event from the gatekeeper service. 
+
+Here's an example of how we are leveraging this feature from our AWS RE:Inforce 2019 session:
+
+<a href="https://www.youtube.com/watch?feature=player_embedded&v=d1V0RNJOFeE" target="_blank"><img src="http://img.youtube.com/vi/d1V0RNJOFeE/hqdefault.jpg" alt="Gatekeeper @ RE:INFORCE 2019" width="480" height="360" border="10" /></a>  
 
 | Property | Description | Type | 
 |----------|-------------|------|

--- a/services/ec2/src/main/java/org/finra/gatekeeper/services/accessrequest/delegates/GrantAccessServiceTask.java
+++ b/services/ec2/src/main/java/org/finra/gatekeeper/services/accessrequest/delegates/GrantAccessServiceTask.java
@@ -111,7 +111,12 @@ public class GrantAccessServiceTask implements JavaDelegate {
                         throw new GatekeeperException("Unsupported platform " + platform);
                 }
 
-                snsService.pushToSNSTopic(accessRequestService.getLiveRequestsForUsersInRequest(EventType.APPROVAL, accessRequest));
+                // If an SNS topic is provided run the queries, otherwise lets skip this step.
+                if(snsService.isTopicSet()) {
+                    snsService.pushToSNSTopic(accessRequestService.getLiveRequestsForUsersInRequest(EventType.APPROVAL, accessRequest));
+                } else {
+                    logger.info("Skip querying of live request data as SNS topic ARN was not provided");
+                }
 
                 linuxNotifications.forEach(notification -> emailServiceWrapper.notifyOfCredentials(accessRequest, notification)); // pass along the key to the user(s)
                 windowsNotifications.forEach(notification -> emailServiceWrapper.notifyOfCancellation(accessRequest, notification)); // pass along any cancelled executions to the user(s)

--- a/services/ec2/src/main/java/org/finra/gatekeeper/services/accessrequest/delegates/RevokeAccessServiceTask.java
+++ b/services/ec2/src/main/java/org/finra/gatekeeper/services/accessrequest/delegates/RevokeAccessServiceTask.java
@@ -120,7 +120,12 @@ public class RevokeAccessServiceTask implements JavaDelegate {
             }
 
             try {
-                snsService.pushToSNSTopic(accessRequestService.getLiveRequestsForUsersInRequest(EventType.EXPIRATION, accessRequest));
+                // If an SNS topic is provided run the queries, otherwise lets skip this step.
+                if(snsService.isTopicSet()) {
+                    snsService.pushToSNSTopic(accessRequestService.getLiveRequestsForUsersInRequest(EventType.EXPIRATION, accessRequest));
+                } else {
+                    logger.info("Skip querying of live request data as SNS topic ARN was not provided");
+                }
             } catch (Exception e) {
                 e.printStackTrace();
                 emailServiceWrapper.notifyAdminsOfFailure(accessRequest, e);

--- a/services/ec2/src/main/java/org/finra/gatekeeper/services/aws/SnsService.java
+++ b/services/ec2/src/main/java/org/finra/gatekeeper/services/aws/SnsService.java
@@ -51,6 +51,10 @@ public class SnsService {
         this.gatekeeperSnsProperties = gatekeeperSnsProperties;
     }
 
+    public boolean isTopicSet(){
+        return gatekeeperSnsProperties.getTopicARN() != null;
+    }
+
     public void pushToSNSTopic(RequestEventDTO message) throws Exception {
         if(gatekeeperSnsProperties.getTopicARN() != null){
             pushToSNSTopic(message, gatekeeperSnsProperties.getTopicARN());


### PR DESCRIPTION
This change makes it so that it will not call getLiveRequests at all if the **gatekeeper.sns.topicARN** configuration property doesn't get set

Signed-off-by: Stephen Mele <Smelecs@gmail.com>