### PR TITLE
Redundancy for the SSM Grant portion for Gatekeeper 

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ The following are configuration properties which tell gatekeeper which documents
 
 | Property | Description | Type |
 |----------|-------------|------|
+| gatekeeper.ssmGrantRetryCount | ( Linux + Windows )The amount of times to retry any instances where creation failed (default is 1 try) | integer
 | gatekeeper.ssm.linux.create.documentName | For Linux: The name of the SSM document Gatekeeper will call to create a user | string
 | gatekeeper.ssm.linux.create.timeout | For Linux: The Amount of time Gatekeeper should wait for the ssm create call to complete | integer
 | gatekeeper.ssm.linux.create.waitInterval | For Linux: The Interval that Gatekeeper polls the SSM create for completion | integer

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ The following are configuration properties which tell gatekeeper which documents
 
 | Property | Description | Type |
 |----------|-------------|------|
-| gatekeeper.ssmGrantRetryCount | ( Linux + Windows )The amount of times to retry any instances where creation failed (default is 1 try) | integer
+| gatekeeper.ssmGrantRetryCount | ( Linux + Windows )The amount of times to retry any instances where creation failed (default is 3 tries) | integer
 | gatekeeper.ssm.linux.create.documentName | For Linux: The name of the SSM document Gatekeeper will call to create a user | string
 | gatekeeper.ssm.linux.create.timeout | For Linux: The Amount of time Gatekeeper should wait for the ssm create call to complete | integer
 | gatekeeper.ssm.linux.create.waitInterval | For Linux: The Interval that Gatekeeper polls the SSM create for completion | integer

--- a/services/ec2/src/main/java/org/finra/gatekeeper/configuration/properties/GatekeeperSsmProperties.java
+++ b/services/ec2/src/main/java/org/finra/gatekeeper/configuration/properties/GatekeeperSsmProperties.java
@@ -28,7 +28,7 @@ public class GatekeeperSsmProperties {
      * The SSM Configuration properties per OS
      */
 
-    private Integer ssmGrantRetryCount = -1;
+    private Integer ssmGrantRetryCount = 3;
     private Map<String, Map<String, SsmDocument>> ssm;
 
     public int getSsmGrantRetryCount() {

--- a/services/ec2/src/main/java/org/finra/gatekeeper/configuration/properties/GatekeeperSsmProperties.java
+++ b/services/ec2/src/main/java/org/finra/gatekeeper/configuration/properties/GatekeeperSsmProperties.java
@@ -27,7 +27,18 @@ public class GatekeeperSsmProperties {
     /**
      * The SSM Configuration properties per OS
      */
+
+    private Integer ssmGrantRetryCount = -1;
     private Map<String, Map<String, SsmDocument>> ssm;
+
+    public int getSsmGrantRetryCount() {
+        return ssmGrantRetryCount;
+    }
+
+    public GatekeeperSsmProperties setSsmGrantRetryCount(int ssmGrantRetryCount) {
+        this.ssmGrantRetryCount = ssmGrantRetryCount;
+        return this;
+    }
 
     public Map<String, Map<String, SsmDocument>> getSsm() {
         return ssm;


### PR DESCRIPTION
This adds a configuration to retry a set amount of times for all of the instances where the SSM calls to create the user did not succeed. This is for both Linux and Windows