### PR TITLE
Update Account Service to have config to be able to override SDLCs for given accounts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,39 @@ Currently Gatekeeper only supports authorization through LDAP, the application e
 #### AWS
 |Property | Description | Type |
 |---------|-------------|------|
-| gatekeeper.accountInfoEndpoint | The Endpoint gatekeeper calls to fetch the account data for all of your aws accounts | string
-| gatekeeper.accountInfoUri | The URI where gatekeeper can call your account Info service. (Defaults to "accounts") | string
 | gatekeeper.aws.proxyHost | (Optional) The Proxy Host. If you are not behind a proxy you can ignore this | string
 | gatekeeper.aws.proxyPort | (Optional) The Proxy Port. If you are not behind a proxy you can ignore this | integer
 | gatekeeper.aws.roleToAssume | The AWS IAM role that Gatekeeper will assume to interact with AWS (e.g. Xacnt_APP_GATEKEEPER)   | string 
+
+#### AWS ACCOUNTS
+These configurations are used by Gatekeeper to manage the data coming from your account service provider.
+
+|Property | Description | Type |
+|---------|-------------|------|
+| gatekeeper.account.serviceURL | The Endpoint gatekeeper calls to fetch the account data for all of your aws accounts | string
+| gatekeeper.account.serviceURI | The URI where gatekeeper can call your account Info service. (Defaults to "accounts") | string
+| gatekeeper.account.sdlcOverrides | A Map telling gatekeeper which account SDLC's to override. See the example below as to how this would look | Map<String, String>
+| gatekeeper.account.sdlcGrouping | A Map allowing you to control the ordering in which accounts show up in the UI based on SDLC, of not set there will be no ordering by SDLC. See Example for how this looks | Map<String, String>
+    
+##### SDLC Overrides
+You can override the SDLC of a given account by providing either it's name or AWS account id. This is useful if you want to have stricter or even looser approval requiremnts on a specific account in a given sdlc.
+
+```dotenv
+    gatekeeper.account.sdlcOverrides.poc=myacc1, 123456789
+    gatekeeper.account.sdlcOverrides.test=myacc2
+```    
+
+##### SDLC Grouping
+The dataset from the account service can get large over time, to control the sorting of these accounts in the UI you may (optionally) specify a grouping to group them up by SDLC. Gatekeeper will sort by the SDLC first and then the given Alias.
+If you do not provide a grouping then the groupings will ultimately default to 1 for all accounts, effectively not sorting on the grouping but the alias alone
+
+```dotenv
+    gatekeeper.account.sdlcGrouping.dev=1
+    gatekeeper.account.sdlcGrouping.qa=2
+    gatekeeper.account.sdlcGrouping.prod=3
+    gatekeeper.account.sdlcGrouping.poc=4
+    gatekeeper.account.sdlcGrouping.test=5
+```
 
 #### EMAIL
 Gatekeeper primarily communicates out temporary credentials via email, these are the properties gatekeeper requires for email

--- a/config/gatekeeper_config.env
+++ b/config/gatekeeper_config.env
@@ -1,4 +1,4 @@
-gatekeeper.accountInfoEndpoint=http://gkaccounts:8080
+gatekeeper.account.serviceURL=http://gkaccounts:8080
 
 gatekeeper.auth.userIdHeader=username
 gatekeeper.appIdentityTag=Application

--- a/services/common/src/main/java/org/finra/gatekeeper/common/properties/GatekeeperAccountProperties.java
+++ b/services/common/src/main/java/org/finra/gatekeeper/common/properties/GatekeeperAccountProperties.java
@@ -1,0 +1,88 @@
+/*
+ *
+ * Copyright 2018. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finra.gatekeeper.common.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@ConfigurationProperties(prefix="gatekeeper.account")
+public class GatekeeperAccountProperties {
+    /**
+     * The URL for the service serving your accounts
+     */
+    private String serviceURL;
+    /**
+     * The URI for the service serving your accounts
+     */
+    private String serviceURI;
+
+    /**
+     * The overrides for SDLC
+     */
+
+    private Map<String, String> sdlcOverrides;
+
+    public String getServiceURL() {
+        return serviceURL;
+    }
+
+    public GatekeeperAccountProperties setServiceURL(String serviceURL) {
+        this.serviceURL = serviceURL;
+        return this;
+    }
+
+    public String getServiceURI() {
+        return serviceURI;
+    }
+
+    public GatekeeperAccountProperties setServiceURI(String serviceURI) {
+        this.serviceURI = serviceURI;
+        return this;
+    }
+
+    /**
+     * This takes the sdlcOverrides map and reverses it so that it is account -> sdlc
+     * @return
+     */
+    public Map<String, String> getAccountSdlcOverrides() {
+        Map<String, String> individualOverrideMapping = new HashMap<>();
+        this.sdlcOverrides.entrySet().forEach(entry -> {
+            final String sdlc = entry.getKey();
+            final List<String> overrideAccountIds = Arrays.asList(entry.getValue().split(","));
+            overrideAccountIds.forEach(account -> {
+                individualOverrideMapping.put(account.trim(), sdlc);
+            });
+        });
+        return individualOverrideMapping;
+    }
+
+    public Map<String, String> getSdlcOverrides() {
+        return sdlcOverrides;
+    }
+
+    public GatekeeperAccountProperties setSdlcOverrides(Map<String, String> sdlcOverrides) {
+        this.sdlcOverrides = sdlcOverrides;
+        return this;
+    }
+}

--- a/services/common/src/main/java/org/finra/gatekeeper/common/properties/GatekeeperAccountProperties.java
+++ b/services/common/src/main/java/org/finra/gatekeeper/common/properties/GatekeeperAccountProperties.java
@@ -43,6 +43,11 @@ public class GatekeeperAccountProperties {
 
     private Map<String, String> sdlcOverrides;
 
+    /**
+     * This is controls the grouping order for SDLC as they appear in the app.
+     */
+    private Map<String, Integer> sdlcGrouping;
+
     public String getServiceURL() {
         return serviceURL;
     }
@@ -83,6 +88,15 @@ public class GatekeeperAccountProperties {
 
     public GatekeeperAccountProperties setSdlcOverrides(Map<String, String> sdlcOverrides) {
         this.sdlcOverrides = sdlcOverrides;
+        return this;
+    }
+
+    public Map<String, Integer> getSdlcGrouping() {
+        return sdlcGrouping;
+    }
+
+    public GatekeeperAccountProperties setSdlcGrouping(Map<String, Integer> sdlcGrouping) {
+        this.sdlcGrouping = sdlcGrouping;
         return this;
     }
 }

--- a/services/common/src/main/java/org/finra/gatekeeper/common/properties/GatekeeperAccountProperties.java
+++ b/services/common/src/main/java/org/finra/gatekeeper/common/properties/GatekeeperAccountProperties.java
@@ -41,12 +41,12 @@ public class GatekeeperAccountProperties {
      * The overrides for SDLC
      */
 
-    private Map<String, String> sdlcOverrides;
+    private Map<String, String> sdlcOverrides = new HashMap<>();
 
     /**
      * This is controls the grouping order for SDLC as they appear in the app.
      */
-    private Map<String, Integer> sdlcGrouping;
+    private Map<String, Integer> sdlcGrouping = new HashMap<>();
 
     public String getServiceURL() {
         return serviceURL;
@@ -72,13 +72,15 @@ public class GatekeeperAccountProperties {
      */
     public Map<String, String> getAccountSdlcOverrides() {
         Map<String, String> individualOverrideMapping = new HashMap<>();
-        this.sdlcOverrides.entrySet().forEach(entry -> {
-            final String sdlc = entry.getKey();
-            final List<String> overrideAccountIds = Arrays.asList(entry.getValue().split(","));
-            overrideAccountIds.forEach(account -> {
-                individualOverrideMapping.put(account.trim(), sdlc);
+        if(!this.sdlcOverrides.isEmpty()) {
+            this.sdlcOverrides.entrySet().forEach(entry -> {
+                final String sdlc = entry.getKey();
+                final List<String> overrideAccountIds = Arrays.asList(entry.getValue().split(","));
+                overrideAccountIds.forEach(account -> {
+                    individualOverrideMapping.put(account.trim(), sdlc);
+                });
             });
-        });
+        }
         return individualOverrideMapping;
     }
 

--- a/services/common/src/main/java/org/finra/gatekeeper/common/services/account/AccountInformationService.java
+++ b/services/common/src/main/java/org/finra/gatekeeper/common/services/account/AccountInformationService.java
@@ -79,6 +79,7 @@ public class AccountInformationService {
         logger.info("Getting Account information from " + gatekeeperAccountProperties.getServiceURL() + gatekeeperAccountProperties.getServiceURI());
 
         Map<String, String> overrideMap = gatekeeperAccountProperties.getAccountSdlcOverrides();
+        Map<String, Integer> sdlcGroupMap = gatekeeperAccountProperties.getSdlcGrouping();
         List<Account> accounts = Arrays.asList(backend2backendService.makeGetCall(gatekeeperAccountProperties.getServiceURL(), gatekeeperAccountProperties.getServiceURI(), true, Account[].class));
 
         accounts.forEach(account -> {
@@ -86,11 +87,17 @@ public class AccountInformationService {
             if(overrideMap.containsKey(account.getAccountId())){
                 logger.info("Found an override for this account ID " + account.getAccountId());
                 account.setSdlc(overrideMap.get(account.getAccountId()));
+                logger.info("SDLC for " + account.getName() + " is now " + account.getSdlc());
             } else if (overrideMap.containsKey(account.getName())) {
                 logger.info("Found an override for this account Name " + account.getName());
                 account.setSdlc(overrideMap.get(account.getName()));
+                logger.info("SDLC for " + account.getName() + " is now " + account.getSdlc());
             }
-            logger.info("SDLC is " + account.getSdlc());
+
+            // set the grouping to match with what the SDLC is.
+            if(sdlcGroupMap.containsKey(account.getSdlc())){
+                account.setGrouping(sdlcGroupMap.get(account.getSdlc()));
+            }
         });
         return accounts;
     }

--- a/services/common/src/main/java/org/finra/gatekeeper/common/services/account/AccountInformationService.java
+++ b/services/common/src/main/java/org/finra/gatekeeper/common/services/account/AccountInformationService.java
@@ -20,16 +20,17 @@ package org.finra.gatekeeper.common.services.account;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import org.finra.gatekeeper.common.properties.GatekeeperAccountProperties;
 import org.finra.gatekeeper.common.services.account.model.Account;
 import org.finra.gatekeeper.common.services.backend2backend.Backend2BackendService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -40,16 +41,12 @@ import java.util.stream.Collectors;
 public class AccountInformationService {
 
     private final Logger logger = LoggerFactory.getLogger(AccountInformationService.class);
-    @Value("${gatekeeper.accountInfoEndpoint}")
-    private String accountInforUrl;
-
-    @Value("${gatekeeper.accountInfoUri}")
-    private String accountInfoUri;
-
+    private final GatekeeperAccountProperties gatekeeperAccountProperties;
     private final Backend2BackendService backend2backendService;
 
     @Autowired
-    public AccountInformationService(Backend2BackendService backend2BackendService){
+    public AccountInformationService(GatekeeperAccountProperties gatekeeperAccountProperties, Backend2BackendService backend2BackendService){
+        this.gatekeeperAccountProperties = gatekeeperAccountProperties;
         this.backend2backendService = backend2BackendService;
     }
 
@@ -66,11 +63,11 @@ public class AccountInformationService {
             });
 
     public List<Account> getAccounts(){
-        return accountCache.getUnchecked(accountInfoUri);
+        return accountCache.getUnchecked(gatekeeperAccountProperties.getServiceURI());
     }
 
     public Account getAccountByAlias(String alias){
-        List<Account> result =  accountCache.getUnchecked(accountInfoUri)
+        List<Account> result =  accountCache.getUnchecked(gatekeeperAccountProperties.getServiceURI())
                 .stream()
                 .filter(account -> account.getAlias().equalsIgnoreCase(alias))
                 .collect(Collectors.toList());
@@ -79,8 +76,23 @@ public class AccountInformationService {
     }
 
     private List<Account> loadAccounts(){
-        logger.info("Getting Account information from " + accountInforUrl + accountInfoUri);
-        return Arrays.asList(backend2backendService.makeGetCall(accountInforUrl, accountInfoUri, true, Account[].class));
+        logger.info("Getting Account information from " + gatekeeperAccountProperties.getServiceURL() + gatekeeperAccountProperties.getServiceURI());
+
+        Map<String, String> overrideMap = gatekeeperAccountProperties.getAccountSdlcOverrides();
+        List<Account> accounts = Arrays.asList(backend2backendService.makeGetCall(gatekeeperAccountProperties.getServiceURL(), gatekeeperAccountProperties.getServiceURI(), true, Account[].class));
+
+        accounts.forEach(account -> {
+            // if the Account ID or the Account Name is in the override map, then replace the SDLC value with what the account name maps to
+            if(overrideMap.containsKey(account.getAccountId())){
+                logger.info("Found an override for this account ID " + account.getAccountId());
+                account.setSdlc(overrideMap.get(account.getAccountId()));
+            } else if (overrideMap.containsKey(account.getName())) {
+                logger.info("Found an override for this account Name " + account.getName());
+                account.setSdlc(overrideMap.get(account.getName()));
+            }
+            logger.info("SDLC is " + account.getSdlc());
+        });
+        return accounts;
     }
 
 }

--- a/services/common/src/main/java/org/finra/gatekeeper/common/services/account/model/Account.java
+++ b/services/common/src/main/java/org/finra/gatekeeper/common/services/account/model/Account.java
@@ -19,9 +19,9 @@ package org.finra.gatekeeper.common.services.account.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Data Transfer Object for Account Info Endpoint call.
@@ -34,6 +34,7 @@ public class Account {
     private String sdlc;
     private String alias;
     private List<Region> regions;
+    private Integer grouping = 1; // Grouping is to be used to help sort on the UI end.
 
     public Account(){}
     public Account(String accountId, String name, String sdlc, String alias, List<Region> regions){
@@ -94,33 +95,35 @@ public class Account {
         return this;
     }
 
-    public boolean equals(Object o){
-        if(this == o){
-            return true;
-        }
-
-        if (o == null || !getClass().equals(o.getClass())) {
-            return false;
-        }
-
-        Account that = (Account)o;
-        return Objects.equals(this.accountId, that.getAccountId())
-                && Objects.equals(this.name, that.getName())
-                && Objects.equals(this.sdlc, that.getSdlc())
-                && Objects.equals(this.alias, that.getAlias())
-                && Objects.equals(this.regions, that.getRegions());
+    public Integer getGrouping() {
+        return grouping;
     }
 
-    public String toString(){
-        return MoreObjects.toStringHelper(this)
-                .add("Account Id", accountId)
-                .add("Name", name)
-                .add("SDLC", sdlc)
-                .add("Alias", alias)
-                .add("Regions", regions)
-                .toString();
-
+    public Account setGrouping(Integer grouping) {
+        this.grouping = grouping;
+        return this;
     }
 
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Account account = (Account) o;
+        return Objects.equal(accountId, account.accountId) &&
+                Objects.equal(name, account.name) &&
+                Objects.equal(sdlc, account.sdlc) &&
+                Objects.equal(alias, account.alias) &&
+                Objects.equal(regions, account.regions) &&
+                Objects.equal(grouping, account.grouping);
+    }
 
+    public String toString() {
+        return "Account{" +
+                "accountId='" + accountId + '\'' +
+                ", name='" + name + '\'' +
+                ", sdlc='" + sdlc + '\'' +
+                ", alias='" + alias + '\'' +
+                ", regions=" + regions +
+                ", grouping=" + grouping +
+                '}';
+    }
 }

--- a/services/common/src/test/java/org/finra/gatekeeper/common/TestApplication.java
+++ b/services/common/src/test/java/org/finra/gatekeeper/common/TestApplication.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finra.gatekeeper.common;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.web.SpringBootServletInitializer;
+import org.springframework.context.annotation.ComponentScan;
+
+/**
+ * This is used for testing only
+ */
+
+@SpringBootApplication
+@ComponentScan({"org.springframework.ldap.core", "org.finra.gatekeeper.common.properties"})
+public class TestApplication extends SpringBootServletInitializer {
+
+  public static void main(String[] args) {
+    new TestApplication().configure(
+        new SpringApplicationBuilder(TestApplication.class)).run(args);
+  }
+}

--- a/services/common/src/test/java/org/finra/gatekeeper/common/properties/GatekeeperAccountPropertiesNotProvidedTest.java
+++ b/services/common/src/test/java/org/finra/gatekeeper/common/properties/GatekeeperAccountPropertiesNotProvidedTest.java
@@ -1,0 +1,40 @@
+package org.finra.gatekeeper.common.properties;
+
+import org.finra.gatekeeper.common.TestApplication;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@SpringApplicationConfiguration(classes = TestApplication.class)
+public class GatekeeperAccountPropertiesNotProvidedTest {
+
+    @Autowired
+    private GatekeeperAccountProperties accountProperties;
+
+    private String expectedURL = "https://testservice.com";
+    private String expectedURI = "/test";
+
+    @Test
+    public void testConfig(){
+        Assert.assertEquals(accountProperties.getServiceURL(), expectedURL);
+        Assert.assertEquals(accountProperties.getServiceURI(), expectedURI);
+    }
+
+    @Test
+    public void testGetAccountSdlcOverrides(){
+        Assert.assertTrue(accountProperties.getSdlcOverrides().isEmpty());
+    }
+
+    @Test
+    public void testGetAccountGrouping(){
+        Assert.assertTrue(accountProperties.getSdlcGrouping().isEmpty());
+    }
+
+}

--- a/services/common/src/test/java/org/finra/gatekeeper/common/properties/GatekeeperAccountPropertiesNotProvidedTest.java
+++ b/services/common/src/test/java/org/finra/gatekeeper/common/properties/GatekeeperAccountPropertiesNotProvidedTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.finra.gatekeeper.common.properties;
 
 import org.finra.gatekeeper.common.TestApplication;

--- a/services/common/src/test/java/org/finra/gatekeeper/common/properties/GatekeeperAccountPropertiesTest.java
+++ b/services/common/src/test/java/org/finra/gatekeeper/common/properties/GatekeeperAccountPropertiesTest.java
@@ -38,4 +38,14 @@ public class GatekeeperAccountPropertiesTest {
         Assert.assertEquals("hello1", accountProperties.getAccountSdlcOverrides().get("myacc1"));
         Assert.assertEquals("hello1", accountProperties.getAccountSdlcOverrides().get("123456789"));
     }
+
+    @Test
+    public void testGetAccountGrouping(){
+        Assert.assertEquals(Integer.valueOf(1), accountProperties.getSdlcGrouping().get("dev"));
+        Assert.assertEquals(Integer.valueOf(2), accountProperties.getSdlcGrouping().get("qa"));
+        Assert.assertEquals(Integer.valueOf(3), accountProperties.getSdlcGrouping().get("prod"));
+        Assert.assertEquals(Integer.valueOf(4), accountProperties.getSdlcGrouping().get("hello1"));
+        Assert.assertEquals(Integer.valueOf(5), accountProperties.getSdlcGrouping().get("hello2"));
+    }
+
 }

--- a/services/common/src/test/java/org/finra/gatekeeper/common/properties/GatekeeperAccountPropertiesTest.java
+++ b/services/common/src/test/java/org/finra/gatekeeper/common/properties/GatekeeperAccountPropertiesTest.java
@@ -1,0 +1,41 @@
+package org.finra.gatekeeper.common.properties;
+
+import org.finra.gatekeeper.common.TestApplication;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ActiveProfiles("unit-test")
+@WebAppConfiguration
+@SpringApplicationConfiguration(classes = TestApplication.class)
+public class GatekeeperAccountPropertiesTest {
+
+    @Autowired
+    private GatekeeperAccountProperties accountProperties;
+
+    private String expectedURL = "https://testservice.com";
+    private String expectedURI = "/test";
+
+    @Test
+    public void testConfig(){
+        Assert.assertEquals(accountProperties.getServiceURL(), expectedURL);
+        Assert.assertEquals(accountProperties.getServiceURI(), expectedURI);
+        Assert.assertEquals(2, accountProperties.getSdlcOverrides().keySet().size());
+        Assert.assertEquals("myacc2", accountProperties.getSdlcOverrides().get("hello2"));
+    }
+
+    @Test
+    public void testGetAccountSdlcOverrides(){
+        Assert.assertEquals("hello2", accountProperties.getAccountSdlcOverrides().get("myacc2"));
+        Assert.assertEquals("hello1", accountProperties.getAccountSdlcOverrides().get("myacc1"));
+        Assert.assertEquals("hello1", accountProperties.getAccountSdlcOverrides().get("123456789"));
+    }
+}

--- a/services/common/src/test/java/org/finra/gatekeeper/common/properties/GatekeeperAccountPropertiesTest.java
+++ b/services/common/src/test/java/org/finra/gatekeeper/common/properties/GatekeeperAccountPropertiesTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.finra.gatekeeper.common.properties;
 
 import org.finra.gatekeeper.common.TestApplication;

--- a/services/common/src/test/java/org/finra/gatekeeper/common/services/account/AccountInformationServiceTest.java
+++ b/services/common/src/test/java/org/finra/gatekeeper/common/services/account/AccountInformationServiceTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.finra.gatekeeper.common.services.account;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/services/common/src/test/java/org/finra/gatekeeper/common/services/account/AccountInformationServiceTest.java
+++ b/services/common/src/test/java/org/finra/gatekeeper/common/services/account/AccountInformationServiceTest.java
@@ -16,10 +16,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {ObjectMapper.class})
@@ -96,11 +93,23 @@ public class AccountInformationServiceTest {
         Assert.assertEquals("hello2", accounts.get(1).getSdlc());
         Assert.assertEquals("hello1", accounts.get(2).getSdlc());
         Assert.assertEquals("prod", accounts.get(3).getSdlc());
+        Assert.assertEquals("devtest", accounts.get(4).getSdlc());
 
         Assert.assertEquals(Integer.valueOf(200), accounts.get(0).getGrouping());
         Assert.assertEquals(Integer.valueOf(50), accounts.get(1).getGrouping());
         Assert.assertEquals(Integer.valueOf(200), accounts.get(2).getGrouping());
         Assert.assertEquals(Integer.valueOf(5), accounts.get(3).getGrouping());
         Assert.assertEquals(Integer.valueOf(1), accounts.get(4).getGrouping());
+    }
+
+    @Test
+    public void testGetAccountsNoOverride(){
+        gatekeeperAccountProperties.setSdlcOverrides(Collections.emptyMap());
+        List<Account> accounts = accountInformationService.getAccounts();
+        Assert.assertEquals("dev", accounts.get(0).getSdlc());
+        Assert.assertEquals("qa", accounts.get(1).getSdlc());
+        Assert.assertEquals("prod", accounts.get(2).getSdlc());
+        Assert.assertEquals("prod", accounts.get(3).getSdlc());
+        Assert.assertEquals("devtest", accounts.get(4).getSdlc());
     }
 }

--- a/services/common/src/test/java/org/finra/gatekeeper/common/services/account/AccountInformationServiceTest.java
+++ b/services/common/src/test/java/org/finra/gatekeeper/common/services/account/AccountInformationServiceTest.java
@@ -1,0 +1,84 @@
+package org.finra.gatekeeper.common.services.account;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.finra.gatekeeper.common.properties.GatekeeperAccountProperties;
+import org.finra.gatekeeper.common.services.account.model.Account;
+import org.finra.gatekeeper.common.services.account.model.Region;
+import org.finra.gatekeeper.common.services.backend2backend.Backend2BackendService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {ObjectMapper.class})
+public class AccountInformationServiceTest {
+
+    @Mock
+    private Backend2BackendService backend2BackendService;
+    private GatekeeperAccountProperties gatekeeperAccountProperties;
+
+    private AccountInformationService accountInformationService;
+
+    private Account a1 = new Account()
+            .setAccountId("34939394939")
+            .setAlias("Account One")
+            .setName("myacc1")
+            .setRegions(Arrays.asList(new Region("us-east-1")))
+            .setSdlc("dev");
+
+    private Account a2 = new Account()
+            .setAccountId("478848334560")
+            .setAlias("Account Two")
+            .setName("myacc2")
+            .setRegions(Arrays.asList(new Region("us-east-1")))
+            .setSdlc("qa");
+
+    private Account a3 = new Account()
+            .setAccountId("123456789")
+            .setAlias("Account Three")
+            .setName("myacc3")
+            .setRegions(Arrays.asList(new Region("us-east-1")))
+            .setSdlc("prod");
+
+    private Account a4 = new Account()
+            .setAccountId("46473773348")
+            .setAlias("Account Four")
+            .setName("myacc4")
+            .setRegions(Arrays.asList(new Region("us-east-1")))
+            .setSdlc("prod");
+
+    @Before
+    public void setup(){
+        Map<String, String> sdlcOverrides = new HashMap<>();
+        sdlcOverrides.put("hello1", "myacc1, 123456789");
+        sdlcOverrides.put("hello2", "myacc2");
+        gatekeeperAccountProperties = new GatekeeperAccountProperties();
+        MockitoAnnotations.initMocks(this);
+        gatekeeperAccountProperties.setServiceURL("helloUrl");
+        gatekeeperAccountProperties.setServiceURI("helloWorld");
+        gatekeeperAccountProperties.setSdlcOverrides(sdlcOverrides);
+        accountInformationService = new AccountInformationService(gatekeeperAccountProperties, backend2BackendService);
+        Mockito.when(backend2BackendService.makeGetCall(Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.any())).thenReturn(new Account[]{a1, a2, a3, a4});
+    }
+
+    @Test
+    public void testGetAccountsSdlcOverride(){
+        List<Account> accounts = accountInformationService.getAccounts();
+        Assert.assertEquals("hello1", accounts.get(0).getSdlc());
+        Assert.assertEquals("hello2", accounts.get(1).getSdlc());
+        Assert.assertEquals("hello1", accounts.get(2).getSdlc());
+        Assert.assertEquals("prod", accounts.get(3).getSdlc());
+    }
+}

--- a/services/common/src/test/java/org/finra/gatekeeper/common/services/account/AccountInformationServiceTest.java
+++ b/services/common/src/test/java/org/finra/gatekeeper/common/services/account/AccountInformationServiceTest.java
@@ -59,26 +59,48 @@ public class AccountInformationServiceTest {
             .setRegions(Arrays.asList(new Region("us-east-1")))
             .setSdlc("prod");
 
+    private Account a5 = new Account()
+            .setAccountId("85843738384")
+            .setAlias("Account Five")
+            .setName("myacc5")
+            .setRegions(Arrays.asList(new Region("us-east-1")))
+            .setSdlc("devtest");
+
     @Before
     public void setup(){
         Map<String, String> sdlcOverrides = new HashMap<>();
         sdlcOverrides.put("hello1", "myacc1, 123456789");
         sdlcOverrides.put("hello2", "myacc2");
+
+        Map<String, Integer> accountSdlcGrouping =  new HashMap<>();
+        accountSdlcGrouping.put("hello1", 200);
+        accountSdlcGrouping.put("hello2", 50);
+        accountSdlcGrouping.put("prod", 5);
+
         gatekeeperAccountProperties = new GatekeeperAccountProperties();
         MockitoAnnotations.initMocks(this);
-        gatekeeperAccountProperties.setServiceURL("helloUrl");
-        gatekeeperAccountProperties.setServiceURI("helloWorld");
-        gatekeeperAccountProperties.setSdlcOverrides(sdlcOverrides);
+        gatekeeperAccountProperties.setServiceURL("helloUrl")
+                .setServiceURI("helloWorld")
+                .setSdlcOverrides(sdlcOverrides)
+                .setSdlcGrouping(accountSdlcGrouping);
+
+
         accountInformationService = new AccountInformationService(gatekeeperAccountProperties, backend2BackendService);
-        Mockito.when(backend2BackendService.makeGetCall(Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.any())).thenReturn(new Account[]{a1, a2, a3, a4});
+        Mockito.when(backend2BackendService.makeGetCall(Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.any())).thenReturn(new Account[]{a1, a2, a3, a4, a5});
     }
 
     @Test
-    public void testGetAccountsSdlcOverride(){
+    public void testGetAccounts(){
         List<Account> accounts = accountInformationService.getAccounts();
         Assert.assertEquals("hello1", accounts.get(0).getSdlc());
         Assert.assertEquals("hello2", accounts.get(1).getSdlc());
         Assert.assertEquals("hello1", accounts.get(2).getSdlc());
         Assert.assertEquals("prod", accounts.get(3).getSdlc());
+
+        Assert.assertEquals(Integer.valueOf(200), accounts.get(0).getGrouping());
+        Assert.assertEquals(Integer.valueOf(50), accounts.get(1).getGrouping());
+        Assert.assertEquals(Integer.valueOf(200), accounts.get(2).getGrouping());
+        Assert.assertEquals(Integer.valueOf(5), accounts.get(3).getGrouping());
+        Assert.assertEquals(Integer.valueOf(1), accounts.get(4).getGrouping());
     }
 }

--- a/services/common/src/test/resources/application.yml
+++ b/services/common/src/test/resources/application.yml
@@ -27,6 +27,13 @@ gatekeeper:
     sdlcOverrides:
       hello1: myacc1, 123456789
       hello2: myacc2
+    sdlcGrouping:
+      dev: 1
+      qa: 2
+      prod: 3
+      hello1: 4
+      hello2: 5
+
   auth:
     ldap:
       isActiveDirectory: false

--- a/services/common/src/test/resources/application.yml
+++ b/services/common/src/test/resources/application.yml
@@ -1,0 +1,46 @@
+#
+#  Copyright 2018. Gatekeeper Contributors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+server.context-path: /api/gatekeeper-ec2
+
+---
+spring:
+  profiles: unit-test
+
+
+gatekeeper:
+  account:
+    serviceURL: https://testservice.com
+    serviceURI: /test
+    sdlcOverrides:
+      hello1: myacc1, 123456789
+      hello2: myacc2
+  auth:
+    ldap:
+      isActiveDirectory: false
+      objectClass: posixAccount
+      usersBase: ou=users
+      userDn: cn=admin,dc=example,dc=org
+      server: ldap://gkldap:389
+      base: dc=example,dc=org
+      userPassword: admin
+      usersCnAttribute: cn
+      usersIdAttribute: uid
+      usersNameAttribute=: cn
+      usersEmailAttribute: email
+      usersDnAttribute: dn
+      pattern: developer_([A-Za-z0-9]+)_dev
+      groupsBase: ou=groups
+---

--- a/services/common/src/test/resources/application.yml
+++ b/services/common/src/test/resources/application.yml
@@ -15,25 +15,10 @@
 #
 server.context-path: /api/gatekeeper-ec2
 
----
-spring:
-  profiles: unit-test
-
-
 gatekeeper:
   account:
     serviceURL: https://testservice.com
     serviceURI: /test
-    sdlcOverrides:
-      hello1: myacc1, 123456789
-      hello2: myacc2
-    sdlcGrouping:
-      dev: 1
-      qa: 2
-      prod: 3
-      hello1: 4
-      hello2: 5
-
   auth:
     ldap:
       isActiveDirectory: false
@@ -50,4 +35,20 @@ gatekeeper:
       usersDnAttribute: dn
       pattern: developer_([A-Za-z0-9]+)_dev
       groupsBase: ou=groups
+---
+spring:
+  profiles: unit-test
+
+gatekeeper:
+  account:
+    sdlcOverrides:
+      hello1: myacc1, 123456789
+      hello2: myacc2
+    sdlcGrouping:
+      dev: 1
+      qa: 2
+      prod: 3
+      hello1: 4
+      hello2: 5
+
 ---

--- a/ui/app/component/ec2/selfservice/template/gatekeeperAWSEc2Component.tpl.html
+++ b/ui/app/component/ec2/selfservice/template/gatekeeperAWSEc2Component.tpl.html
@@ -23,7 +23,7 @@
                 <md-input-container md-no-float>
                     <label>Select an Account</label>
                     <md-select ng-model="gkSelfServiceCtrl.forms.awsInstanceForm.selectedAccount" ng-change="gkSelfServiceCtrl.clearInstances()" required>
-                        <md-option ng-value="opt" ng-repeat="opt in gkSelfServiceCtrl.awsAccounts">{{ opt.alias }}</md-option>
+                        <md-option ng-value="opt" ng-repeat="opt in gkSelfServiceCtrl.awsAccounts | orderBy:['grouping','alias']">{{ opt.alias }}</md-option>
                     </md-select>
                 </md-input-container>
             </div>

--- a/ui/app/component/rds/selfservice/template/gatekeeperAWSRdsComponent.tpl.html
+++ b/ui/app/component/rds/selfservice/template/gatekeeperAWSRdsComponent.tpl.html
@@ -23,7 +23,7 @@
                 <md-input-container md-no-float>
                     <label>Select an Account</label>
                     <md-select ng-model="ctrl.forms.awsInstanceForm.selectedAccount" ng-change="ctrl.clearInstances()" required>
-                        <md-option ng-value="opt" ng-repeat="opt in ctrl.awsAccounts">{{ opt.alias }}</md-option>
+                        <md-option ng-value="opt" ng-repeat="opt in ctrl.awsAccounts | orderBy:['grouping','alias']">{{ opt.alias }}</md-option>
                     </md-select>
                 </md-input-container>
             </div>


### PR DESCRIPTION
Updated the Account Service to be able to override SDLC values for agiven list of accounts.

This is useful for when you have a lower(or higher) environment where you want to tighten (or lax) approval restrictions.