### PR TITLE
Change gatekeeper.requiredSecurityGroup to support multiple Group Names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ These configurations are specific to Gatekeeper RDS
 | Property | Description | Type |
 |----------|-------------|------|
 | gatekeeper.db.schema | The schema in which gatekeeper operates its tables  | string
-| gatekeeper.requiredSecurityGroup | The Security Group in which Gatekeeper RDS requires for connectivity | string 
+| gatekeeper.requiredSecurityGroups | A comma separated list of the Security Group(s) in which Gatekeeper RDS requires for connectivity | string 
 | gatekeeper.rds.postgresMinServerVersion | The minimum postgrs server to use | string 
 | gatekeeper.rds.ssl | Whether Gatekeeeper-RDS should use SSL or not to connect | boolean
 | gatekeeper.rds.connectTimeout | The timeout (in milliseconds) to wait for a connection | Integer

--- a/services/rds/src/main/java/org/finra/gatekeeper/configuration/GatekeeperProperties.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/configuration/GatekeeperProperties.java
@@ -506,7 +506,7 @@ public class GatekeeperProperties {
     /**
      * The Security Group to check on each RDS instance
      */
-    private String requiredSecurityGroup;
+    private String requiredSecurityGroups;
 
     /**
      * The Tag to determine which application a resource belongs to.
@@ -524,12 +524,12 @@ public class GatekeeperProperties {
         return this;
     }
 
-    public String getRequiredSecurityGroup() {
-        return requiredSecurityGroup;
+    public String getRequiredSecurityGroups() {
+        return requiredSecurityGroups;
     }
 
-    public GatekeeperProperties setRequiredSecurityGroup(String requiredSecurityGroup) {
-        this.requiredSecurityGroup = requiredSecurityGroup;
+    public GatekeeperProperties setRequiredSecurityGroups(String requiredSecurityGroups) {
+        this.requiredSecurityGroups = requiredSecurityGroups;
         return this;
     }
 

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/RdsLookupService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/RdsLookupService.java
@@ -19,9 +19,6 @@ package org.finra.gatekeeper.services.aws;
 
 import com.amazonaws.services.rds.AmazonRDSClient;
 import com.amazonaws.services.rds.model.*;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import org.finra.gatekeeper.configuration.GatekeeperProperties;
 import org.finra.gatekeeper.rds.model.DbUser;
 import org.finra.gatekeeper.rds.model.RoleType;
@@ -36,7 +33,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -135,7 +131,7 @@ public class RdsLookupService {
                     status = "Unsupported (Read-Only replica of " +item.getReadReplicaSourceDBInstanceIdentifier() + ")";
                 }
                 if(!enabled){
-                    status = "Missing FINRA-RDS-support Security Group";
+                    status = "Missing one of the following Security Group(s): " + gatekeeperProperties.getRequiredSecurityGroups();
                 }else{
                     //if enabled lets check if the DB is working
 

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/RdsLookupService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/RdsLookupService.java
@@ -131,7 +131,7 @@ public class RdsLookupService {
                     status = "Unsupported (Read-Only replica of " +item.getReadReplicaSourceDBInstanceIdentifier() + ")";
                 }
                 if(!enabled){
-                    status = "Missing one of the following Security Group(s): " + gatekeeperProperties.getRequiredSecurityGroups();
+                    status = "Missing Gatekeeper RDS support Security Group";
                 }else{
                     //if enabled lets check if the DB is working
 

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/SGLookupService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/SGLookupService.java
@@ -30,10 +30,8 @@ import org.finra.gatekeeper.services.aws.model.AWSEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import javax.inject.Inject;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -47,7 +45,7 @@ public class SGLookupService {
 
     private final Logger logger = LoggerFactory.getLogger(SGLookupService.class);
 
-    private final String securityGroupName;
+    private final String securityGroupNames;
 
     private AwsSessionService awsSessionService;
 
@@ -55,7 +53,7 @@ public class SGLookupService {
     public SGLookupService(AwsSessionService awsSessionService,
                            GatekeeperProperties gatekeeperProperties){
         this.awsSessionService = awsSessionService;
-        this.securityGroupName = gatekeeperProperties.getRequiredSecurityGroup();
+        this.securityGroupNames = gatekeeperProperties.getRequiredSecurityGroups();
     }
 
     /*
@@ -87,12 +85,12 @@ public class SGLookupService {
 
         Filter groupNameFilter = new Filter();
         groupNameFilter.setName("group-name");
-        groupNameFilter.setValues(Collections.singletonList(securityGroupName));
+        groupNameFilter.setValues(Arrays.asList(securityGroupNames.split(",")));
 
         AmazonEC2Client amazonEC2Client = awsSessionService.getEC2Session(environment);
         DescribeSecurityGroupsResult result = amazonEC2Client.describeSecurityGroups(describeSecurityGroupsRequest.withFilters(groupNameFilter));
 
-        logger.info("found " + result.getSecurityGroups().size() + " Security Groups with name '" + securityGroupName + "'");
+        logger.info("found " + result.getSecurityGroups().size() + " Security Groups with name(s) '" + securityGroupNames + "'");
         return result.getSecurityGroups().stream()
                 .map(SecurityGroup::getGroupId)
                 .collect(Collectors.toList());


### PR DESCRIPTION
- Change the requiredSeurityGroup to be requiredSecurityGroups
- Remove unused imports in RdsLookupService
- Update status message to state that the supplied properties are missing
- SGLookupService will now look for the security groups based on a comma separated list (used to only filter in a singular manner)
- Updated documentation to reflect the changes to the properties

#75 