### PR TITLE
If the user cannot be revoked, rotate the user's password instead

### DIFF
--- a/services/rds/src/main/java/org/finra/gatekeeper/services/db/DatabaseConnectionService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/db/DatabaseConnectionService.java
@@ -79,8 +79,9 @@ public class DatabaseConnectionService {
         databases.forEach(db -> {
             logger.info("Revoking access on " + db.getName() + "(" + db.getEndpoint() + ")");
             try{
-                statusMap.put(db.getName(), databaseConnectionFactory.getConnection(db.getEngine()).revokeAccess(user, roleType, getAddress(db.getEndpoint(), db.getDbName())));
-                logger.info("User " + user + " successfully removed from " + db.getName() + "(" + db.getInstanceId() + ")");
+                Boolean result = databaseConnectionFactory.getConnection(db.getEngine()).revokeAccess(user, roleType, getAddress(db.getEndpoint(), db.getDbName()));
+                statusMap.put(db.getName(), result);
+                logger.info("User " + user + " removed from " + db.getName() + "(" + db.getInstanceId() + ")? " + result);
             }catch(GKUnsupportedDBException e){
                 logger.info("Skipping access for " + db.getName() + " as Engine " + db.getEngine() + " is not supported");
             }catch(Exception e){


### PR DESCRIPTION
This change updates some of the logging as well as introduces a quality of life fix to rotate the users password if it already exists and cannot be deleted in PostreSQL