### PR TITLE
RDS, Postgres - If the user account cannot be removed, rotate the password for the user

### DIFF
--- a/services/rds/src/main/java/org/finra/gatekeeper/services/db/DatabaseConnectionService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/db/DatabaseConnectionService.java
@@ -79,8 +79,9 @@ public class DatabaseConnectionService {
         databases.forEach(db -> {
             logger.info("Revoking access on " + db.getName() + "(" + db.getEndpoint() + ")");
             try{
-                statusMap.put(db.getName(), databaseConnectionFactory.getConnection(db.getEngine()).revokeAccess(user, roleType, getAddress(db.getEndpoint(), db.getDbName())));
-                logger.info("User " + user + " successfully removed from " + db.getName() + "(" + db.getInstanceId() + ")");
+                Boolean result = databaseConnectionFactory.getConnection(db.getEngine()).revokeAccess(user, roleType, getAddress(db.getEndpoint(), db.getDbName()));
+                statusMap.put(db.getName(), result);
+                logger.info("User " + user + " removed from " + db.getName() + "(" + db.getInstanceId() + ")? " + result);
             }catch(GKUnsupportedDBException e){
                 logger.info("Skipping access for " + db.getName() + " as Engine " + db.getEngine() + " is not supported");
             }catch(Exception e){


### PR DESCRIPTION
This brings a quality of life change for RDS users of the application that interact with Postgres databases. This change will try to remove the account like before but if it cannot be revoked the application will instead rotate the user's password and update the account's expiration date.