### PR TITLE
Update Gatekeeper to use latest spring boot (2)

### DIFF
--- a/services/common/pom.xml
+++ b/services/common/pom.xml
@@ -19,7 +19,6 @@
         <java.version>1.8</java.version>
         <freemarker.version>2.3.20</freemarker.version>
         <commons.version>3.4</commons.version>
-        <spring.security.version>4.0.3.RELEASE</spring.security.version>
     </properties>
 
     <dependencies>
@@ -59,9 +58,8 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-ldap</artifactId>
-            <version>${spring.security.version}</version>
+            <groupId>org.springframework.ldap</groupId>
+            <artifactId>spring-ldap-core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/services/common/src/main/java/org/finra/gatekeeper/GatekeeperCommonConfig.java
+++ b/services/common/src/main/java/org/finra/gatekeeper/GatekeeperCommonConfig.java
@@ -32,8 +32,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
-import org.springframework.boot.context.embedded.FilterRegistrationBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
@@ -138,7 +138,7 @@ public class GatekeeperCommonConfig {
     }
 
     @Bean
-    @ConfigurationProperties(prefix = "spring.ldap.contextSource")
+    @ConfigurationProperties(prefix = "spring.ldap.context-source")
     public LdapContextSource authContextSource() {
         LdapContextSource contextSource = new LdapContextSource();
         contextSource.setBase(userBase);

--- a/services/common/src/test/java/org/finra/gatekeeper/common/TestApplication.java
+++ b/services/common/src/test/java/org/finra/gatekeeper/common/TestApplication.java
@@ -18,7 +18,7 @@ package org.finra.gatekeeper.common;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.context.web.SpringBootServletInitializer;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.ComponentScan;
 
 /**

--- a/services/common/src/test/java/org/finra/gatekeeper/common/properties/GatekeeperAccountPropertiesNotProvidedTest.java
+++ b/services/common/src/test/java/org/finra/gatekeeper/common/properties/GatekeeperAccountPropertiesNotProvidedTest.java
@@ -22,14 +22,14 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-@SpringApplicationConfiguration(classes = TestApplication.class)
+@SpringBootTest(classes = TestApplication.class)
 public class GatekeeperAccountPropertiesNotProvidedTest {
 
     @Autowired

--- a/services/common/src/test/java/org/finra/gatekeeper/common/properties/GatekeeperAccountPropertiesTest.java
+++ b/services/common/src/test/java/org/finra/gatekeeper/common/properties/GatekeeperAccountPropertiesTest.java
@@ -22,8 +22,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -32,7 +31,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ActiveProfiles("unit-test")
 @WebAppConfiguration
-@SpringApplicationConfiguration(classes = TestApplication.class)
+@SpringBootTest(classes = TestApplication.class)
 public class GatekeeperAccountPropertiesTest {
 
     @Autowired

--- a/services/ec2/pom.xml
+++ b/services/ec2/pom.xml
@@ -36,7 +36,7 @@
         <bouncycastle.version>1.56</bouncycastle.version>
         <compiler.version>3.3</compiler.version>
         <failsafe.version>2.19.1</failsafe.version>
-        <freemarker.version>2.3.20</freemarker.version>
+        <freemarker.version>2.3.29</freemarker.version>
         <java.version>1.8</java.version>
         <postgres.version>42.2.1</postgres.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/services/ec2/src/main/java/org/finra/Application.java
+++ b/services/ec2/src/main/java/org/finra/Application.java
@@ -16,15 +16,17 @@
 
 package org.finra;
 
+import org.activiti.spring.boot.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.context.web.SpringBootServletInitializer;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 /**
  * The Entry Point for the Application
  */
 
-@SpringBootApplication
+// Exclude the ActivitiSecurityAutoConfiguration class from being initialized because this doesn't work with Spring boot 2
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class Application extends SpringBootServletInitializer {
 
   public static void main(String[] args) {

--- a/services/ec2/src/main/java/org/finra/gatekeeper/configuration/GatekeeperConfig.java
+++ b/services/ec2/src/main/java/org/finra/gatekeeper/configuration/GatekeeperConfig.java
@@ -17,13 +17,10 @@
 
 package org.finra.gatekeeper.configuration;
 
+import freemarker.template.Configuration;
 import freemarker.template.TemplateExceptionHandler;
 import org.finra.gatekeeper.services.email.EmailService;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.ldap.core.ContextSource;
-import org.springframework.ldap.core.LdapTemplate;
-import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.stereotype.Component;
 
 import java.util.Locale;
@@ -32,19 +29,8 @@ import java.util.Locale;
 public class GatekeeperConfig {
 
     @Bean
-    @ConfigurationProperties(prefix = "spring.ldap.contextSource")
-    public LdapContextSource contextSource() {
-        return new LdapContextSource();
-    }
-
-    @Bean
-    public LdapTemplate ldapTemplate(ContextSource contextSource) {
-        return new LdapTemplate(contextSource);
-    }
-
-    @Bean
-    public freemarker.template.Configuration freemarkerConfig() {
-        freemarker.template.Configuration configuration = new freemarker.template.Configuration();
+    public Configuration freemarkerConfig() {
+        Configuration configuration = new Configuration(Configuration.VERSION_2_3_29);
         configuration.setClassForTemplateLoading(EmailService.class, "/emails");
         configuration.setDefaultEncoding("UTF-8");
         configuration.setLocale(Locale.US);

--- a/services/ec2/src/main/java/org/finra/gatekeeper/configuration/properties/GatekeeperApprovalProperties.java
+++ b/services/ec2/src/main/java/org/finra/gatekeeper/configuration/properties/GatekeeperApprovalProperties.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Component
-@ConfigurationProperties(prefix="gatekeeper.approvalThreshold")
+@ConfigurationProperties(prefix="gatekeeper.approval-threshold")
 public class GatekeeperApprovalProperties {
     /**
      * Thresholds for DEV Role

--- a/services/ec2/src/main/java/org/finra/gatekeeper/services/accessrequest/AccessRequestService.java
+++ b/services/ec2/src/main/java/org/finra/gatekeeper/services/accessrequest/AccessRequestService.java
@@ -184,7 +184,7 @@ public class AccessRequestService {
         List<ActiveAccessRequestWrapper> response = new ArrayList<>();
         tasks.forEach(task -> {
             AccessRequest theRequest = updateInstanceStatus(
-                    accessRequestRepository.findOne(Long.valueOf(
+                    accessRequestRepository.getAccessRequestById(Long.parseLong(
                             runtimeService.getVariableInstance(task.getExecutionId(), "accessRequest").getTextValue2())
                     ));
             response.add(new ActiveAccessRequestWrapper(theRequest)
@@ -229,9 +229,8 @@ public class AccessRequestService {
 
         //run a query to grab all of the access requests that we found in activiti (this pretty much returns all
         //for now, until we implement it to use a time window)
-        accessRequestRepository.findAll(activitiAccessRequestMap.values()).forEach(accessRequest -> {
-            gkAccessRequestMap.put(accessRequest.getId(), accessRequest);
-        });
+        accessRequestRepository.getAccessRequestsByIdIn(activitiAccessRequestMap.values())
+                .forEach(accessRequest -> { gkAccessRequestMap.put(accessRequest.getId(), accessRequest); });
 
     /*  this one's kind of a hack but this query gets the RequestStatus value for a request
         we do it like this because once again if the package name changes it won't update the database and will
@@ -352,7 +351,7 @@ public class AccessRequestService {
      * @param action - the action taken on the request
      */
     private void updateRequestDetails(Long requestId, String approverComments, String action){
-        AccessRequest accessRequest = accessRequestRepository.findOne(requestId);
+        AccessRequest accessRequest = accessRequestRepository.getAccessRequestById(requestId);
         accessRequest.setApproverComments(approverComments);
         GatekeeperUserEntry user = gatekeeperRoleService.getUserProfile();
         accessRequest.setActionedByUserId(user.getUserId());
@@ -415,7 +414,7 @@ public class AccessRequestService {
                 });
 
         List<CompletedAccessRequestWrapper> requests = new ArrayList<>();
-        accessRequestRepository.findAll(historicData.keySet()).forEach(accessRequest -> {
+        accessRequestRepository.getAccessRequestsByIdIn(historicData.keySet()).forEach(accessRequest -> {
             Map<String, Object> data = historicData.get(accessRequest.getId());
             CompletedAccessRequestWrapper completedAccessRequestWrapper = new CompletedAccessRequestWrapper(accessRequest);
             completedAccessRequestWrapper.setUpdated((Date)data.get(updated));

--- a/services/ec2/src/main/java/org/finra/gatekeeper/services/accessrequest/model/AccessRequestRepository.java
+++ b/services/ec2/src/main/java/org/finra/gatekeeper/services/accessrequest/model/AccessRequestRepository.java
@@ -18,8 +18,13 @@ package org.finra.gatekeeper.services.accessrequest.model;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * Repo object for AccessRequest domain
  */
 public interface AccessRequestRepository extends JpaRepository<AccessRequest, Long> {
+    AccessRequest getAccessRequestById(Long id);
+    List<AccessRequest> getAccessRequestsByIdIn(Collection<Long> ids);
 }

--- a/services/ec2/src/main/resources/application.yml
+++ b/services/ec2/src/main/resources/application.yml
@@ -14,8 +14,7 @@
 #  limitations under the License.
 #
 #Global stuff, Most of this stuff should be set with container profile
-server.context-path: /api/gatekeeper-ec2
-
+server.servlet.context-path: /api/gatekeeper-ec2
 gatekeeper:
   aws:
     proxyHost: unset
@@ -38,7 +37,7 @@ gatekeeper:
   db:
     sslParams: ssl=true&sslmode=${gatekeeper.db.sslMode}&sslrootcert=${gatekeeper.db.sslCert}
 
-  approvalThreshold:
+  approval-threshold:
     dev:
       dev: 48
       qa: 48
@@ -99,9 +98,6 @@ cloud:
 
 log:
   filename: application.log
-
-logging:
-  level: info
 
 ---
 

--- a/services/ec2/src/main/resources/logback.xml
+++ b/services/ec2/src/main/resources/logback.xml
@@ -7,9 +7,9 @@
         <encoder>
             <pattern>${FILE_LOG_PATTERN}</pattern>
         </encoder>
-        <file>${LOG_FILE}</file>
+        <file>${LOG_FILE}.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>${LOG_FILE}.%i</fileNamePattern>
+            <fileNamePattern>${LOG_FILE}.log.%i</fileNamePattern>
             <minIndex>1</minIndex>
             <maxIndex>10</maxIndex>
         </rollingPolicy>
@@ -21,11 +21,11 @@
 
     <root level="INFO">
         <appender-ref ref="CONSOLE" />
-        <!--<appender-ref ref="FILE" />-->
+        <appender-ref ref="FILE" />
     </root>
     <!--<root level="DEBUG">-->
-        <!--<appender-ref ref="CONSOLE" />-->
-        <!--<appender-ref ref="FILE" />-->
+    <!--<appender-ref ref="CONSOLE" />-->
+    <!--<appender-ref ref="FILE" />-->
     <!--</root>-->
 
 </configuration>

--- a/services/ec2/src/test/java/org/finra/gatekeeper/services/accessrequest/AccessRequestServiceTest.java
+++ b/services/ec2/src/test/java/org/finra/gatekeeper/services/accessrequest/AccessRequestServiceTest.java
@@ -48,7 +48,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.context.ActiveProfiles;
 
 import static org.mockito.Matchers.any;
@@ -213,7 +213,6 @@ public class AccessRequestServiceTest {
 
         when(ownerRequestWrapper.getInstances()).thenReturn(instances);
         when(ownerRequestWrapper.getHours()).thenReturn(1);
-        when(ownerRequestWrapper.getRequestorId()).thenReturn("owner");
         when(ownerRequestWrapper.getAccount()).thenReturn("testAccount");
         when(ownerRequestWrapper.getRegion()).thenReturn("testRegion");
         when(ownerRequestWrapper.getPlatform()).thenReturn("testPlatform");
@@ -246,8 +245,8 @@ public class AccessRequestServiceTest {
         when(ownerOneTaskInstance.getTextValue2()).thenReturn("1");
         when(ownerTwoTaskInstance.getTextValue2()).thenReturn("2");
 
-        when(accessRequestRepository.findOne(1L)).thenReturn(ownerRequest);
-        when(accessRequestRepository.findOne(2L)).thenReturn(nonOwnerRequest);
+        when(accessRequestRepository.getAccessRequestById(1L)).thenReturn(ownerRequest);
+        when(accessRequestRepository.getAccessRequestById(2L)).thenReturn(nonOwnerRequest);
 
         when(runtimeService.getVariableInstance("ownerOneTask", "accessRequest")).thenReturn(ownerOneTaskInstance);
         when(runtimeService.getVariableInstance("ownerTwoTask", "accessRequest")).thenReturn(ownerTwoTaskInstance);
@@ -320,7 +319,7 @@ public class AccessRequestServiceTest {
         when(ssmService.checkInstancesWithSsm(any(),any())).thenReturn(statusMap);
 
         when(accountInformationService.getAccountByAlias(any())).thenReturn(mockAccount);
-        when(accessRequestRepository.findAll(Mockito.anyList())).thenReturn(Arrays.asList(ownerRequest, nonOwnerRequest));
+        when(accessRequestRepository.getAccessRequestsByIdIn(Mockito.anyCollection())).thenReturn(Arrays.asList(ownerRequest, nonOwnerRequest));
 
     }
 
@@ -620,7 +619,7 @@ public class AccessRequestServiceTest {
      */
     @Test
     public void testApproval(){
-        Mockito.when(accessRequestRepository.findOne(1L)).thenReturn(ownerRequest);
+        Mockito.when(accessRequestRepository.getAccessRequestById(1L)).thenReturn(ownerRequest);
         accessRequestService.approveRequest("taskOne", 1L, "A reason");
         Map<String,Object> statusMap = new HashMap<>();
         statusMap.put("requestStatus", RequestStatus.APPROVAL_GRANTED);
@@ -635,7 +634,7 @@ public class AccessRequestServiceTest {
      */
     @Test
     public void testRejected(){
-        Mockito.when(accessRequestRepository.findOne(1L)).thenReturn(nonOwnerRequest);
+        Mockito.when(accessRequestRepository.getAccessRequestById(1L)).thenReturn(nonOwnerRequest);
         accessRequestService.rejectRequest("taskOne", 1L, "Another Reason");
         Map<String,Object> statusMap = new HashMap<>();
         statusMap.put("requestStatus", RequestStatus.APPROVAL_REJECTED);

--- a/services/ec2/src/test/java/org/finra/gatekeeper/services/accessrequest/LiveAccessRequestServiceTest.java
+++ b/services/ec2/src/test/java/org/finra/gatekeeper/services/accessrequest/LiveAccessRequestServiceTest.java
@@ -32,12 +32,11 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.*;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 /**
@@ -210,7 +209,7 @@ public class LiveAccessRequestServiceTest {
                 .list())
                 .thenReturn(Arrays.asList(activitiRequest1, activitiRequest2, activitiRequest3));
 
-        when(accessRequestRepository.findAll(Mockito.anyList()))
+        when(accessRequestRepository.getAccessRequestsByIdIn(Mockito.anyCollection()))
                 .thenReturn(Arrays.asList(request1, request2, request3));
     }
 }

--- a/services/ec2/src/test/java/org/finra/gatekeeper/services/accessrequest/delegates/RevokeAccessServiceTest.java
+++ b/services/ec2/src/test/java/org/finra/gatekeeper/services/accessrequest/delegates/RevokeAccessServiceTest.java
@@ -33,7 +33,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -65,7 +65,7 @@ public class RevokeAccessServiceTest {
     @Mock
     private JobQuery mockjobQuery = new JobQueryImpl();
     @Mock
-    private JobEntity mockJobEntity = new JobEntity() {};
+    private JobEntity mockJobEntity;
 
     @InjectMocks
     private RevokeAccessServiceTask revokeAccessServiceTask;
@@ -77,6 +77,7 @@ public class RevokeAccessServiceTest {
         Mockito.when(mockjobQuery.processInstanceId(Mockito.anyString())).thenReturn(mockjobQuery);
         Mockito.when(mockjobQuery.singleResult()).thenReturn(mockJobEntity);
         Mockito.when(mockJobEntity.getRetries()).thenReturn(2);
+        Mockito.when(execution.getProcessInstanceId()).thenReturn("1");
 
         mockRequest = new AccessRequest()
                 .setId(1L)

--- a/services/ec2/src/test/java/org/finra/gatekeeper/services/accessrequest/model/AWSInstanceTest.java
+++ b/services/ec2/src/test/java/org/finra/gatekeeper/services/accessrequest/model/AWSInstanceTest.java
@@ -20,7 +20,7 @@ import com.google.common.base.MoreObjects;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  *

--- a/services/ec2/src/test/java/org/finra/gatekeeper/services/accessrequest/model/AccessRequestTest.java
+++ b/services/ec2/src/test/java/org/finra/gatekeeper/services/accessrequest/model/AccessRequestTest.java
@@ -20,7 +20,7 @@ import com.google.common.base.MoreObjects;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.List;

--- a/services/ec2/src/test/java/org/finra/gatekeeper/services/accessrequest/model/RequestStatusTest.java
+++ b/services/ec2/src/test/java/org/finra/gatekeeper/services/accessrequest/model/RequestStatusTest.java
@@ -19,7 +19,7 @@ package org.finra.gatekeeper.services.accessrequest.model;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Tests for AccessRequest object

--- a/services/ec2/src/test/java/org/finra/gatekeeper/services/accessrequest/model/UserTest.java
+++ b/services/ec2/src/test/java/org/finra/gatekeeper/services/accessrequest/model/UserTest.java
@@ -20,7 +20,7 @@ import com.google.common.base.MoreObjects;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Tests for AccessRequest object

--- a/services/ec2/src/test/java/org/finra/gatekeeper/services/aws/AwsSessionServiceTest.java
+++ b/services/ec2/src/test/java/org/finra/gatekeeper/services/aws/AwsSessionServiceTest.java
@@ -40,7 +40,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -95,8 +95,6 @@ public class AwsSessionServiceTest {
         awsEnvironment = new AWSEnvironment("Dev", "us-west-2");
         Mockito.when(gatekeeperAwsProperties.getSessionTimeout()).thenReturn(900000);
         Mockito.when(gatekeeperAwsProperties.getSessionTimeoutPad()).thenReturn(60000);
-        Mockito.when(gatekeeperAwsProperties.getProxyHost()).thenReturn("testproxy");
-        Mockito.when(gatekeeperAwsProperties.getProxyPort()).thenReturn("100");
 
         List<Region> regions = new ArrayList<>();
         Region testRegion1 = new Region();

--- a/services/ec2/src/test/java/org/finra/gatekeeper/services/aws/Ec2LookupServiceTest.java
+++ b/services/ec2/src/test/java/org/finra/gatekeeper/services/aws/Ec2LookupServiceTest.java
@@ -29,7 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.*;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ActiveProfiles;
 

--- a/services/ec2/src/test/java/org/finra/gatekeeper/services/aws/SsmServiceTest.java
+++ b/services/ec2/src/test/java/org/finra/gatekeeper/services/aws/SsmServiceTest.java
@@ -30,15 +30,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.*;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -108,13 +106,9 @@ public class SsmServiceTest {
         when(user.getEmail()).thenReturn("testUserEmail");
         when(user.getUserId()).thenReturn("testUserId");
         when(user.getName()).thenReturn("testUserName");
-        when(user.getId()).thenReturn(20L);
 
-        when(accessRequest.getPlatform()).thenReturn("Windows");
         when(accessRequest.getAccount()).thenReturn("DEV");
         when(accessRequest.getHours()).thenReturn(5);
-        when(accessRequest.getRegion()).thenReturn("us-east-1");
-        when(accessRequest.getInstances()).thenReturn(new ArrayList<AWSInstance>());
         when(accessRequest.getId()).thenReturn(10L);
 
 
@@ -138,11 +132,11 @@ public class SsmServiceTest {
         when(secondDescribeInstanceInformationResult.getNextToken()).thenReturn(null);
         when(secondDescribeInstanceInformationResult.getInstanceInformationList()).thenReturn(secondInstanceInformationList);
 
-        when(awsSessionService.getSsmSession(any())).thenReturn(awsSimpleSystemsManagementClient);
-        when(awsSimpleSystemsManagementClient.sendCommand(anyObject())).thenReturn(fakeResult);
-        when(awsSimpleSystemsManagementClient.listCommandInvocations(anyObject())).thenReturn(fakeCommandList);
+        when(awsSessionService.getSsmSession(Mockito.any())).thenReturn(awsSimpleSystemsManagementClient);
+        when(awsSimpleSystemsManagementClient.sendCommand(Mockito.any())).thenReturn(fakeResult);
+        when(awsSimpleSystemsManagementClient.listCommandInvocations(Mockito.any())).thenReturn(fakeCommandList);
 
-        when(awsSimpleSystemsManagementClient.describeInstanceInformation(any())).thenReturn(firstDescribeInstanceInformationResult);
+        when(awsSimpleSystemsManagementClient.describeInstanceInformation(Mockito.any())).thenReturn(firstDescribeInstanceInformationResult);
         Map<String, GatekeeperSsmProperties.SsmDocument> linuxDocumentMap = new HashMap<>();
 
 
@@ -187,8 +181,6 @@ public class SsmServiceTest {
     public void testCreateUserAccount(){
         Map<String, String> results = ssmService.createUserAccount(awsEnvironment, Arrays.asList("i-1","i-2"), "theUser", "HelloKey", "Linux", "23");
         Assert.assertTrue("Verify that the ssm succeeds for Linux", results.containsValue("Success"));
-
-
         SendCommandRequest scr = new SendCommandRequest()
                 .withInstanceIds( Arrays.asList("i-1","i-2"))
                 .withDocumentName("test-linux-create")
@@ -197,11 +189,13 @@ public class SsmServiceTest {
                 .addParametersEntry("hours", Arrays.asList("23"))
                 .addParametersEntry("executionTimeout",Arrays.asList("15"));
         verify(awsSimpleSystemsManagementClient, times(1)).sendCommand(scr);
+    }
 
-        results = ssmService.createUserAccount(awsEnvironment, Arrays.asList("i-3","i-4"), user, accessRequest, "Windows");
-        Assert.assertTrue("Verify that the ssm succeeds for Windows",  results.containsValue("Success"));
-
-        scr = new SendCommandRequest()
+    @Test
+    public void testCreateUserAccountWindows(){
+        Map<String, String> results = ssmService.createUserAccount(awsEnvironment, Arrays.asList("i-3","i-4"), user, accessRequest, "Windows");
+        Assert.assertTrue("Verify that the ssm succeeds for Linux", results.containsValue("Success"));
+        SendCommandRequest scr = new SendCommandRequest()
                 .withInstanceIds( Arrays.asList("i-3","i-4"))
                 .withDocumentName("test-windows-create")
                 .addParametersEntry("userName",Arrays.asList("testUserName"))
@@ -216,7 +210,6 @@ public class SsmServiceTest {
                 .addParametersEntry("executionTimeout",Arrays.asList("5"));
         verify(awsSimpleSystemsManagementClient, times(1)).sendCommand(scr);
     }
-
     @Test
     public void testCreateUserAccountFails(){
         ListCommandInvocationsResult fakeCommandList = new ListCommandInvocationsResult();
@@ -227,7 +220,7 @@ public class SsmServiceTest {
         fakeCommand2.setCommandId("fake");
         fakeCommand2.setStatus(CommandInvocationStatus.Success);
         fakeCommandList.setCommandInvocations(Arrays.asList(fakeCommand1, fakeCommand2));
-        when(awsSimpleSystemsManagementClient.listCommandInvocations(anyObject())).thenReturn(fakeCommandList);
+        when(awsSimpleSystemsManagementClient.listCommandInvocations(Mockito.any())).thenReturn(fakeCommandList);
         Map<String, String> results = ssmService.createUserAccount(awsEnvironment, Arrays.asList("i-1","i-2"), "theUser", "HelloKey", "Linux", "23");
         Assert.assertFalse("Verify that the ssm reports false and times out", !results.containsValue("Success"));
     }
@@ -236,7 +229,7 @@ public class SsmServiceTest {
     public void testCreateUserAccountTimesOut(){
         ListCommandInvocationsResult timeout = new ListCommandInvocationsResult();
         timeout.setCommandInvocations(new ArrayList<>());
-        when(awsSimpleSystemsManagementClient.listCommandInvocations(anyObject())).thenReturn(timeout);
+        when(awsSimpleSystemsManagementClient.listCommandInvocations(Mockito.any())).thenReturn(timeout);
         Map<String, String> results = ssmService.createUserAccount(awsEnvironment, Arrays.asList("i-1","i-2"), "theUser", "HelloKey", "Linux", "23");
         Assert.assertFalse("Verify that the ssm reports false and times out",results.containsValue("Success"));
     }
@@ -273,7 +266,7 @@ public class SsmServiceTest {
         Assert.assertTrue("Verify the correct status is returned", statusMap.get(firstInstanceInformation.getInstanceId()).equals(firstInstanceInformation.getPingStatus()));
 
         when(firstDescribeInstanceInformationResult.getNextToken()).thenReturn("ABC");
-        when(awsSimpleSystemsManagementClient.describeInstanceInformation(any())).thenReturn(firstDescribeInstanceInformationResult).thenReturn(secondDescribeInstanceInformationResult);
+        when(awsSimpleSystemsManagementClient.describeInstanceInformation(Mockito.any())).thenReturn(firstDescribeInstanceInformationResult).thenReturn(secondDescribeInstanceInformationResult);
 
         statusMap = ssmService.checkInstancesWithSsm(awsEnvironment,instanceIds);
 

--- a/services/ec2/src/test/java/org/finra/gatekeeper/services/aws/model/AWSEnvironmentTest.java
+++ b/services/ec2/src/test/java/org/finra/gatekeeper/services/aws/model/AWSEnvironmentTest.java
@@ -20,7 +20,7 @@ import com.google.common.base.MoreObjects;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Objects;

--- a/services/ec2/src/test/java/org/finra/gatekeeper/services/aws/model/GatekeeperAWSInstanceTest.java
+++ b/services/ec2/src/test/java/org/finra/gatekeeper/services/aws/model/GatekeeperAWSInstanceTest.java
@@ -20,7 +20,7 @@ import com.google.common.base.MoreObjects;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Objects;

--- a/services/ec2/src/test/java/org/finra/gatekeeper/services/mail/EmailServiceWrapperTest.java
+++ b/services/ec2/src/test/java/org/finra/gatekeeper/services/mail/EmailServiceWrapperTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -81,23 +81,19 @@ public class EmailServiceWrapperTest {
     @Before
     public void initMocks() throws Exception {
         //Mocking out the method calls
-        when(emailService.sendEmailWithAttachment(anyString(),anyString(),anyString(),anyString(),anyString(),anyMap(),anyString(),anyString(),anyMap(),anyString())).thenReturn(null);
         when(emailService.sendEmail(anyString(),anyString(),anyString(),anyString(),anyString(),anyMap())).thenReturn(null);
 
         //A mock user
         when(testUser.getEmail()).thenReturn(testUserEmail);
-        when(testUser.getUserId()).thenReturn(testUserId);
 
         //The mock request
         List<User> users = new ArrayList<User>();
         users.add(testUser);
         when(request.getUsers()).thenReturn(users);
         when(request.getId()).thenReturn(125L);
-        when(request.getAccount()).thenReturn("TEP");
         when(request.getRequestorEmail()).thenReturn(requestEmail);
         List<AWSInstance> instances = new ArrayList<AWSInstance>();
 
-        when(instance.getIp()).thenReturn("127.0.0.1");
         instances.add(instance);
         when(request.getInstances()).thenReturn(instances);
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -35,12 +35,12 @@
         <guava.version>24.0-jre</guava.version>
         <h2.version>1.4.185</h2.version>
         <junit.version>5.0.0</junit.version>
-        <logback.version>1.1.2</logback.version>
+        <logback.version>1.2.3</logback.version>
         <pl.project13.maven.version>2.1.15</pl.project13.maven.version>
         <plexus-resources.version>1.0-alpha-7</plexus-resources.version>
-        <spring.boot.version>1.3.3.RELEASE</spring.boot.version>
+        <spring.boot.version>2.2.0.RELEASE</spring.boot.version>
         <spring.cloud.version>1.0.6.RELEASE</spring.cloud.version>
-        <spring.ldap.version>2.0.3.RELEASE</spring.ldap.version>
+        <spring.ldap.version>2.3.1.RELEASE</spring.ldap.version>
         <slf4j.version>1.7.25</slf4j.version>
         <maven-surefire-plugin.version>2.16</maven-surefire-plugin.version>
         <maven-surefire-reports-plugin.version>2.16</maven-surefire-reports-plugin.version>
@@ -114,7 +114,7 @@
             </dependency>
             <dependency>
                 <groupId>org.springframework.ldap</groupId>
-                <artifactId>spring-ldap-core</artifactId>
+                <artifactId>spring-ldap</artifactId>
                 <version>${spring.ldap.version}</version>
             </dependency>
             <dependency>

--- a/services/rds/pom.xml
+++ b/services/rds/pom.xml
@@ -36,7 +36,7 @@
         <aws.sdk.version>1.11.333</aws.sdk.version>
 		<compiler.version>3.3</compiler.version>
 		<failsafe.version>2.19.1</failsafe.version>
-		<freemarker.version>2.3.20</freemarker.version>
+		<freemarker.version>2.3.29</freemarker.version>
 		<h2.version>1.4.185</h2.version>
 		<java.version>1.8</java.version>
 		<mysql.version>6.0.5</mysql.version>

--- a/services/rds/src/main/java/org/finra/gatekeeper/Application.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/Application.java
@@ -17,11 +17,14 @@
 
 package org.finra.gatekeeper;
 
+
+import org.activiti.spring.boot.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.context.web.SpringBootServletInitializer;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
-@SpringBootApplication
+// Exclude the ActivitiSecurityAutoConfiguration class from being initialized because this doesn't work with Spring boot 2
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class Application extends SpringBootServletInitializer {
 
     public static void main(String[] args) {

--- a/services/rds/src/main/java/org/finra/gatekeeper/configuration/AppConfig.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/configuration/AppConfig.java
@@ -17,13 +17,12 @@
 
 package org.finra.gatekeeper.configuration;
 
+import freemarker.template.Configuration;
 import freemarker.template.TemplateExceptionHandler;
 import org.finra.gatekeeper.services.email.EmailService;
 
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 
 import java.util.Locale;
 
@@ -31,13 +30,11 @@ import java.util.Locale;
  * Configuration file used to set up beans like ClientConfiguration
  * or any other AWS clients such as S3, SQS, etc.
  */
-@Configuration
-@ComponentScan("org.finra")
-@EnableAutoConfiguration
+@Component
 public class AppConfig {
     @Bean
     public freemarker.template.Configuration freemarkerConfig() {
-        freemarker.template.Configuration configuration = new freemarker.template.Configuration();
+        Configuration configuration = new freemarker.template.Configuration(freemarker.template.Configuration.VERSION_2_3_29);
         configuration.setClassForTemplateLoading(EmailService.class, "/emails");
         configuration.setDefaultEncoding("UTF-8");
         configuration.setLocale(Locale.US);

--- a/services/rds/src/main/java/org/finra/gatekeeper/configuration/GatekeeperApprovalProperties.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/configuration/GatekeeperApprovalProperties.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 import java.util.*;
 
 @Component
-@ConfigurationProperties(prefix="gatekeeper.approvalThreshold")
+@ConfigurationProperties(prefix="gatekeeper.approval-threshold")
 public class GatekeeperApprovalProperties {
     /**
      * Thresholds for DEV Role

--- a/services/rds/src/main/java/org/finra/gatekeeper/configuration/GatekeeperOverrideProperties.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/configuration/GatekeeperOverrideProperties.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Set;
 
 @Component
-@ConfigurationProperties(prefix="gatekeeper.overridePolicy")
+@ConfigurationProperties(prefix="gatekeeper.override-policy")
 public class GatekeeperOverrideProperties {
 
     @Autowired

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/AccessRequestService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/AccessRequestService.java
@@ -220,7 +220,7 @@ public class AccessRequestService {
         List<Task> tasks = taskService.createTaskQuery().active().list();
         List<ActiveAccessRequestWrapper> response = new ArrayList<>();
         tasks.forEach(task -> {
-            AccessRequest theRequest = accessRequestRepository.findOne(Long.valueOf(
+            AccessRequest theRequest = accessRequestRepository.getAccessRequestById(Long.valueOf(
                     runtimeService.getVariableInstance(task.getExecutionId(), "accessRequest").getTextValue2())
             );
 
@@ -266,7 +266,7 @@ public class AccessRequestService {
 
         //run a query to grab all of the access requests that we found in activiti (this pretty much returns all
         //for now, until we implement it to use a time window)
-        accessRequestRepository.findAll(activitiAccessRequestMap.values()).forEach(accessRequest -> {
+        accessRequestRepository.getAccessRequestsByIdIn(activitiAccessRequestMap.values()).forEach(accessRequest -> {
             gkAccessRequestMap.put(accessRequest.getId(), accessRequest);
         });
 
@@ -337,7 +337,7 @@ public class AccessRequestService {
      * @param action - the action taken on the request
      */
     private void updateRequestDetails(Long requestId, String approverComments, String action){
-        AccessRequest accessRequest = accessRequestRepository.findOne(requestId);
+        AccessRequest accessRequest = accessRequestRepository.getAccessRequestById(requestId);
         accessRequest.setApproverComments(approverComments);
         GatekeeperUserEntry user = gatekeeperRoleService.getUserProfile();
         accessRequest.setActionedByUserId(user.getUserId());

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/model/AccessRequestRepository.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/model/AccessRequestRepository.java
@@ -19,8 +19,13 @@ package org.finra.gatekeeper.services.accessrequest.model;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * Repo object for AccessRequest domain
  */
 public interface AccessRequestRepository extends JpaRepository<AccessRequest, Long> {
+    AccessRequest getAccessRequestById(Long id);
+    List<AccessRequest> getAccessRequestsByIdIn(Collection<Long> ids);
 }

--- a/services/rds/src/main/resources/application.yml
+++ b/services/rds/src/main/resources/application.yml
@@ -15,7 +15,7 @@
 #
 #Global stuff
 #This stuff is usually replaced by the container profile, feel free to set them to what you need should you find yourself doing local development
-server.context-path: /api/gatekeeper-rds
+server.servlet.context-path: /api/gatekeeper-rds
 
 gatekeeper:
   aws:

--- a/services/rds/src/main/resources/logback.xml
+++ b/services/rds/src/main/resources/logback.xml
@@ -7,9 +7,9 @@
         <encoder>
             <pattern>${FILE_LOG_PATTERN}</pattern>
         </encoder>
-        <file>${LOG_FILE}</file>
+        <file>${LOG_FILE}.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>${LOG_FILE}.%i</fileNamePattern>
+            <fileNamePattern>${LOG_FILE}.log.%i</fileNamePattern>
             <minIndex>1</minIndex>
             <maxIndex>10</maxIndex>
         </rollingPolicy>
@@ -21,6 +21,11 @@
 
     <root level="INFO">
         <appender-ref ref="CONSOLE" />
-    <!--<appender-ref ref="FILE" /> -->
+        <appender-ref ref="FILE" />
     </root>
+
+    <!--<root level="DEBUG">-->
+    <!--<appender-ref ref="CONSOLE" />-->
+    <!--<appender-ref ref="FILE" />-->
+    <!--</root>-->
 </configuration>

--- a/services/rds/src/test/java/org/finra/gatekeeper/configuration/PropertyConfigApprovalThresholdTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/configuration/PropertyConfigApprovalThresholdTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.*;
@@ -20,7 +20,9 @@ import java.util.*;
 /**
  * Tests for custom stuff in PropertyConfig
  */
-@RunWith(MockitoJUnitRunner.class)
+
+// Exclude the ActivitiSecurityAutoConfiguration class from being initialized because this doesn't work with Spring boot 2
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class PropertyConfigApprovalThresholdTest {
 
     @InjectMocks

--- a/services/rds/src/test/java/org/finra/gatekeeper/configuration/PropertyConfigOverridePolicyTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/configuration/PropertyConfigOverridePolicyTest.java
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.*;

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/accessrequest/AccessRequestServiceTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/accessrequest/AccessRequestServiceTest.java
@@ -28,7 +28,6 @@ import org.activiti.engine.impl.persistence.entity.VariableInstance;
 import org.activiti.engine.runtime.ProcessInstanceQuery;
 import org.activiti.engine.task.Task;
 import org.activiti.engine.task.TaskQuery;
-import org.finra.gatekeeper.common.authfilter.parser.IGatekeeperUserProfile;
 import org.finra.gatekeeper.common.services.user.model.GatekeeperUserEntry;
 import org.finra.gatekeeper.configuration.GatekeeperApprovalProperties;
 import org.finra.gatekeeper.configuration.GatekeeperOverrideProperties;
@@ -50,13 +49,12 @@ import org.finra.gatekeeper.services.auth.GatekeeperRoleService;
 import org.finra.gatekeeper.services.auth.GatekeeperRdsRole;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.*;
 
@@ -66,7 +64,7 @@ import static org.mockito.Mockito.*;
 /**
  * Tests for the Gatekeeper RDS Access Request Service
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class AccessRequestServiceTest {
 
     @InjectMocks
@@ -204,8 +202,6 @@ public class AccessRequestServiceTest {
         when(ownerRequest.getId()).thenReturn(1L);
         when(ownerRequest.getAccountSdlc()).thenReturn("dev");
 
-
-
         //Non-owner mock
         when(nonOwnerRequest.getAccount()).thenReturn("DEV");
         when(nonOwnerRequest.getAwsRdsInstances()).thenReturn(instances);
@@ -259,8 +255,8 @@ public class AccessRequestServiceTest {
         when(ownerOneTaskInstance.getTextValue2()).thenReturn("1");
         when(ownerTwoTaskInstance.getTextValue2()).thenReturn("2");
 
-        when(accessRequestRepository.findOne(1L)).thenReturn(ownerRequest);
-        when(accessRequestRepository.findOne(2L)).thenReturn(nonOwnerRequest);
+        when(accessRequestRepository.getAccessRequestById(1L)).thenReturn(ownerRequest);
+        when(accessRequestRepository.getAccessRequestById(2L)).thenReturn(nonOwnerRequest);
 
         when(runtimeService.getVariableInstance("ownerOneTask", "accessRequest")).thenReturn(ownerOneTaskInstance);
         when(runtimeService.getVariableInstance("ownerTwoTask", "accessRequest")).thenReturn(ownerTwoTaskInstance);
@@ -332,7 +328,7 @@ public class AccessRequestServiceTest {
 
         initMockAccount("dev");
         initApprovalThresholds(OWNER_APPLICATION, MOCK_MAXIMUM, MOCK_MAXIMUM, MOCK_MAXIMUM);
-        when(accessRequestRepository.findAll(Mockito.anyList())).thenReturn(Arrays.asList(ownerRequest, nonOwnerRequest));
+        when(accessRequestRepository.getAccessRequestsByIdIn(Mockito.anyCollection())).thenReturn(Arrays.asList(ownerRequest, nonOwnerRequest));
     }
 
 
@@ -670,7 +666,7 @@ public class AccessRequestServiceTest {
      */
     @Test
     public void testApproval(){
-        Mockito.when(accessRequestRepository.findOne(1L)).thenReturn(ownerRequest);
+        Mockito.when(accessRequestRepository.getAccessRequestById(1L)).thenReturn(ownerRequest);
         accessRequestService.approveRequest("taskOne", 1L, "A reason");
         Map<String,Object> statusMap = new HashMap<>();
         statusMap.put("requestStatus", RequestStatus.APPROVAL_GRANTED);
@@ -685,7 +681,7 @@ public class AccessRequestServiceTest {
      */
     @Test
     public void testRejected(){
-        Mockito.when(accessRequestRepository.findOne(1L)).thenReturn(ownerRequest);
+        Mockito.when(accessRequestRepository.getAccessRequestById(1L)).thenReturn(ownerRequest);
         accessRequestService.rejectRequest("taskOne", 1L, "Another Reason");
         Map<String,Object> statusMap = new HashMap<>();
         statusMap.put("requestStatus", RequestStatus.APPROVAL_REJECTED);

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/roles/GatekeeperRoleServiceTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/roles/GatekeeperRoleServiceTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.ldap.core.LdapTemplate;
 
 import java.util.*;
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.*;
 /**
  * Unit tests for GatekeeperRoleService
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class GatekeeperRoleServiceTest {
 
     @Mock


### PR DESCRIPTION
#7 

Updates Gatekeeper Backend Services to use Spring Boot 2.2.0

Many of these changes are just updates to imports and changes to parts of the app that were deprecated.

GatekeeperCommonConfig - Updates to no longer use CamelCase in @Configuration Properties
GatekeeperApprovalProperties - Updates to no longer use CamelCase in @Configuration Properties
GatekeeperConfig (EC2 + RDS Service) - Had to update FreeMarker library for Spring boot 2 as the original version no longer worked.
AccessRequestRepository (EC2 + RDS Service) - Updated to use JPA methods for searching for single access requests and multi access requests
AccessRequestService (EC2 + RDS Service) - Updated to use new AccessRequestRepository JPA Methods
Application (EC2 + RDS Service) - Updated to exclude Activiti's Security Auto Configuration (The app doesn't leverage this functionality of Activiti anyways)
application.yml (EC2 + RDS Service) - Updated to use server.servlet.context-path (previous is deprecated)
logback.xml - Updated to work with latest version (old version didn't work with Springboot 2)

Tests - Updated tests to work with SpringBoot 2 + any code that had to get changed.

We haven't updated spring boot in a long time, so i thought it would be a good idea to get it updated, but of course other changes had to be made since it was a big jump.

Signed-off-by: Stephen Mele <Smelecs@gmail.com>