### PR TITLE
Fix for spring datasource configurations when migrating the code from spring boot 1 to 2

### DIFF
--- a/services/ec2/src/main/resources/application.yml
+++ b/services/ec2/src/main/resources/application.yml
@@ -142,5 +142,7 @@ spring:
     url: jdbc:postgresql://${gatekeeper.db.url}:${gatekeeper.db.port}/${gatekeeper.db.database}?ApplicationName=GatekeeperEC2&currentSchema=${gatekeeper.db.schema}&${gatekeeper.db.sslParams}
     username: ${gatekeeper.db.user}
     password: ${gatekeeper.db.password}
-    max-idle: 2
-    min-idle: 2
+    hikari:
+      minimum-idle: 2
+      maximum-pool-size: 2
+

--- a/services/rds/src/main/resources/application.yml
+++ b/services/rds/src/main/resources/application.yml
@@ -182,8 +182,9 @@ spring:
     url: jdbc:postgresql://${gatekeeper.db.url}:${gatekeeper.db.port}/${gatekeeper.db.database}?ApplicationName=GatekeeperRDS&currentSchema=${gatekeeper.db.schema}&${gatekeeper.db.sslParams}
     username: ${gatekeeper.db.user}
     password: ${gatekeeper.db.password}
-    max-idle: 2
-    min-idle: 2
+    hikari:
+      minimum-idle: 2
+      maximum-pool-size: 2
 
 gatekeeper:
   db:


### PR DESCRIPTION
properties that need to be set to limit database connections changed when migrating to spring boot 1 -> 2. Updating these to line up with the way it's done in 2

Signed-off-by: Stephen Mele <Smelecs@gmail.com>