### PR TITLE
Update Gatekeeper RDS to work with Aurora Clusters. 

### DIFF
--- a/services/rds/src/main/java/org/finra/gatekeeper/controllers/DatabaseController.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/controllers/DatabaseController.java
@@ -50,7 +50,7 @@ public class DatabaseController {
     public List<DbUser> removeUsersFromDatabase(@RequestBody RemoveUsersWrapper removeUsersWrapper) throws Exception {
         AWSEnvironment awsEnvironment = new AWSEnvironment(removeUsersWrapper.getAccount(), removeUsersWrapper.getRegion());
         try {
-            GatekeeperRDSInstance rdsInstance = rdsLookupService.getOneInstance(awsEnvironment, removeUsersWrapper.getDb()).get();
+            GatekeeperRDSInstance rdsInstance = rdsLookupService.getOneInstance(awsEnvironment, removeUsersWrapper.getInstanceId(), removeUsersWrapper.getInstanceName()).get();
             List<String> result = this.databaseConnectionService.forceRevokeAccessUsersOnDatabase( rdsInstance, removeUsersWrapper.getUsers());
             if(!result.isEmpty()){
                 throw new GatekeeperException("Failed to remove the following users: " + result + ". Please verify that they do not have any dependent objects; " +
@@ -58,10 +58,10 @@ public class DatabaseController {
             }
         } catch (Exception e ) {
             throw new GatekeeperException("Error while trying to revoke the following users: " + removeUsersWrapper.getUsers()
-                    + " On database " + removeUsersWrapper.getDb() + " on account " + removeUsersWrapper.getAccount() + " ("
+                    + " On database " + removeUsersWrapper.getInstanceName() + " on account " + removeUsersWrapper.getAccount() + " ("
                     + removeUsersWrapper.getRegion() + ") - " + e.getMessage() , e);
         }
 
-        return rdsLookupService.getUsersForInstance(awsEnvironment, removeUsersWrapper.getDb());
+        return rdsLookupService.getUsersForInstance(awsEnvironment, removeUsersWrapper.getInstanceId(), removeUsersWrapper.getInstanceName());
     }
 }

--- a/services/rds/src/main/java/org/finra/gatekeeper/controllers/LookupController.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/controllers/LookupController.java
@@ -53,21 +53,22 @@ class LookupController {
 
     @RequestMapping(value = "/searchDBInstances", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public List<GatekeeperRDSInstance> searchRDSInstances(@RequestParam("account") String account, @RequestParam("region") String region,
-                                                          @RequestParam("searchText") String searchString){
-        return rdsLookupService.getInstances(new AWSEnvironment(account.toUpperCase(), region), searchString.toLowerCase());
+                                                          @RequestParam("searchText") String searchString, @RequestParam("type") String type){
+        return rdsLookupService.getInstances(new AWSEnvironment(account.toUpperCase(), region), type, searchString.toLowerCase());
     }
 
     @RequestMapping(value = "/getAvailableSchemas", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public Map<RoleType, List<String>> getAvailableSchemas(@RequestParam("account") String account, @RequestParam("region") String region,
-                                                           @RequestParam("instanceId") String instanceId) throws Exception{
-        return rdsLookupService.getSchemasForInstance(new AWSEnvironment(account.toUpperCase(), region), instanceId);
+                                                           @RequestParam("instanceId") String instanceId, @RequestParam("instanceName") String instanceName) throws Exception{
+        return rdsLookupService.getSchemasForInstance(new AWSEnvironment(account.toUpperCase(), region), instanceId, instanceName);
     }
 
     @RequestMapping(value="/getUsers", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public List<DbUser> getUsersForInstance(@RequestParam("account") String account,
                                             @RequestParam("region") String region,
+                                            @RequestParam("instanceId") String instanceId,
                                             @RequestParam("instanceName") String instanceName) throws Exception{
-        return rdsLookupService.getUsersForInstance(new AWSEnvironment(account.toUpperCase(), region), instanceName);
+        return rdsLookupService.getUsersForInstance(new AWSEnvironment(account.toUpperCase(), region), instanceId, instanceName);
 
     }
 }

--- a/services/rds/src/main/java/org/finra/gatekeeper/controllers/wrappers/RemoveUsersWrapper.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/controllers/wrappers/RemoveUsersWrapper.java
@@ -25,7 +25,8 @@ public class RemoveUsersWrapper {
 
     private String account;
     private String region;
-    private String db;
+    private String instanceId;
+    private String instanceName;
     private List<DbUser> users;
 
     public String getAccount() {
@@ -46,12 +47,21 @@ public class RemoveUsersWrapper {
         return this;
     }
 
-    public String getDb() {
-        return db;
+    public String getInstanceId() {
+        return instanceId;
     }
 
-    public RemoveUsersWrapper setDb(String db) {
-        this.db = db;
+    public RemoveUsersWrapper setInstanceId(String instanceId) {
+        this.instanceId = instanceId;
+        return this;
+    }
+
+    public String getInstanceName() {
+        return instanceName;
+    }
+
+    public RemoveUsersWrapper setInstanceName(String instanceName) {
+        this.instanceName = instanceName;
         return this;
     }
 
@@ -67,8 +77,8 @@ public class RemoveUsersWrapper {
 
     public RemoveUsersWrapper() {}
 
-    public RemoveUsersWrapper(String db, List<DbUser> users) {
-        this.db = db;
+    public RemoveUsersWrapper(String instanceName, List<DbUser> users) {
+        this.instanceName = instanceName;
         this.users = users;
     }
 }

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/RdsLookupService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/RdsLookupService.java
@@ -24,6 +24,7 @@ import org.finra.gatekeeper.rds.model.DbUser;
 import org.finra.gatekeeper.rds.model.RoleType;
 import org.finra.gatekeeper.services.aws.model.AWSEnvironment;
 import org.finra.gatekeeper.services.aws.model.GatekeeperRDSInstance;
+import org.finra.gatekeeper.services.aws.model.LookupType;
 import org.finra.gatekeeper.services.db.DatabaseConnectionService;
 import org.finra.gatekeeper.rds.exception.GKUnsupportedDBException;
 import org.slf4j.Logger;
@@ -44,10 +45,19 @@ public class RdsLookupService {
 
     private final Logger logger = LoggerFactory.getLogger(RdsLookupService.class);
 
+    protected static final String STATUS_MISSING_SGS = "Missing Gatekeeper RDS support Security Group";
+    protected static final String STATUS_NO_INSTANCES = "This Cluster has no associated instances";
+    protected static final String STATUS_NO_WRITERS = "This Cluster has no associated writer instances";
+    protected static final String STATUS_UNSUPPORTED_DB_ENGINE = "DB Engine not supported";
+    protected static final String STATUS_COULD_NOT_FETCH_ROLES = "Could not fetch roles available to DB";
+    protected static final String STATUS_UNABLE_TO_LOGIN = "Gatekeeper user does not exist or password is incorrect.";
+
     private final AwsSessionService awsSessionService;
     private final DatabaseConnectionService databaseConnectionService;
     private final SGLookupService sgLookupService;
     private final GatekeeperProperties gatekeeperProperties;
+    private final String STATUS_AVAILABLE = "available";
+    private final String STATUS_BACKING_UP = "backing-up";
 
     @Autowired
     public RdsLookupService(AwsSessionService awsSessionService,
@@ -60,13 +70,74 @@ public class RdsLookupService {
         this.gatekeeperProperties = gatekeeperProperties;
     }
 
-    private List<GatekeeperRDSInstance> doFilter(AWSEnvironment environment, String searchString) {
-        return loadInstances(environment, instance -> instance.getDBInstanceIdentifier().toLowerCase().contains(searchString.toLowerCase())
-                || instance.getDbiResourceId().toLowerCase().contains(searchString.toLowerCase()));
+
+    public List<GatekeeperRDSInstance> getInstances(AWSEnvironment environment, String lookupType, String searchString) {
+        switch(LookupType.valueOf(lookupType.toUpperCase())){
+            case RDS:
+                return doFilterRds(environment, searchString);
+            case AURORA:
+                return doFilterAurora(environment, searchString);
+            default:
+                return Collections.emptyList();
+        }
     }
 
-    public List<GatekeeperRDSInstance> getInstances(AWSEnvironment environment, String searchString) {
-        return doFilter(environment, searchString);
+    public Optional<GatekeeperRDSInstance> getOneInstance(AWSEnvironment environment, String dbInstanceIdentifier, String instanceName) {
+        logger.info(dbInstanceIdentifier);
+        Long startTime = System.currentTimeMillis();
+        List<String> securityGroupIds = sgLookupService.fetchSgsForAccountRegion(environment);
+        AmazonRDSClient amazonRDSClient = awsSessionService.getRDSSession(environment);
+        List<GatekeeperRDSInstance> gatekeeperRDSInstances;
+
+        //if it's an aurora cluster, the resrouce will start with "cluster"
+        if(dbInstanceIdentifier.startsWith("cluster")){
+            DescribeDBClustersResult result = amazonRDSClient.describeDBClusters(
+                    new DescribeDBClustersRequest().withDBClusterIdentifier(instanceName));
+            gatekeeperRDSInstances = loadToGatekeeperRDSInstanceAurora(amazonRDSClient, result.getDBClusters(), securityGroupIds);
+        }else {
+            DescribeDBInstancesResult result = amazonRDSClient.describeDBInstances(new DescribeDBInstancesRequest().withDBInstanceIdentifier(instanceName));
+            gatekeeperRDSInstances = loadToGatekeeperRDSInstance(amazonRDSClient, result.getDBInstances(), securityGroupIds);
+        }
+
+        logger.info("Fetched Instance in " + ((double)(System.currentTimeMillis() - startTime) / 1000) + " Seconds");
+
+        Optional<GatekeeperRDSInstance> gatekeeperRDSInstance = Optional.of(gatekeeperRDSInstances.get(0));
+        return gatekeeperRDSInstance;
+    }
+
+    public Map<RoleType, List<String>> getSchemasForInstance(AWSEnvironment environment, String instanceId, String instanceName) throws Exception{
+        logger.info("Getting Schema info for " +instanceName + "(" + instanceId + ") On Account " + environment.getAccount() + " and Region " + environment.getRegion());
+        Optional<GatekeeperRDSInstance> instance = getOneInstance(environment, instanceId, instanceName);
+        if(instance.isPresent()){
+            return databaseConnectionService.getAvailableSchemasForDb(instance.get());
+        }else{
+            return unavailableMap();
+        }
+    }
+
+    @PreAuthorize("@gatekeeperRoleService.isApprover()")
+    public List<DbUser> getUsersForInstance(AWSEnvironment environment, String instanceId, String instanceName) throws Exception {
+        Optional<GatekeeperRDSInstance> instance = getOneInstance(environment, instanceId, instanceName);
+
+        if(instance.isPresent()){
+            return databaseConnectionService.getUsersForDb(instance.get());
+        }else{
+            logger.error("Could not find database with " + instanceName + " on account " + environment.getAccount() + "(" + environment.getRegion() + ")");
+            return Collections.emptyList();
+        }
+    }
+
+    private List<GatekeeperRDSInstance> doFilterRds(AWSEnvironment environment, String searchString) {
+        // Get all instances that match the given search string
+        return loadInstances(environment, instance -> (instance.getDBInstanceIdentifier().toLowerCase().contains(searchString.toLowerCase())
+                || instance.getDbiResourceId().toLowerCase().contains(searchString.toLowerCase())) && !instance.getEngine().contains("aurora"));
+    }
+
+    private List<GatekeeperRDSInstance> doFilterAurora(AWSEnvironment environment, String searchString) {
+        // Get all instances that match the given search string
+        return loadInstancesAurora(environment, instance ->
+                instance.getDBClusterIdentifier().toLowerCase().contains(searchString.toLowerCase())
+                        || instance.getDbClusterResourceId().toLowerCase().contains(searchString.toLowerCase()));
     }
 
     private String getApplicationTagforInstanceArn(AmazonRDSClient client, String arn){
@@ -88,19 +159,24 @@ public class RdsLookupService {
 
         instances.forEach(item -> {
             String application = getApplicationTagforInstanceArn(client, item.getDBInstanceArn());
-            if(item.getDBInstanceStatus().equalsIgnoreCase("available")) {
-                Boolean enabled = item.getVpcSecurityGroups().stream()
+            boolean enabled = false;
+            String status = item.getDBInstanceStatus();
+            Integer port = item.getEndpoint().getPort();
+            List<String> availableRoles = null;
+            String dbName = item.getDBName();
+            String address = getAddress(item.getEndpoint().getAddress(),String.valueOf(port),dbName);
+
+            if(item.getDBInstanceStatus().equalsIgnoreCase(STATUS_AVAILABLE)
+                    || item.getDBInstanceStatus().equalsIgnoreCase(STATUS_BACKING_UP)) {
+                enabled = item.getVpcSecurityGroups().stream()
                         .anyMatch(sg -> {
                             return securityGroupIds.contains(sg.getVpcSecurityGroupId());
                         });
-
-                String status = item.getDBInstanceStatus();
-                String dbName = item.getDBName();
-                Integer port = item.getEndpoint().getPort();
-                List<String> availableRoles = null;
-
+                if(!enabled){
+                    status = STATUS_MISSING_SGS;
+                }
                 // If the database engine is an oracle based engine then we need to go dig the SSL port out thru the options.
-                if(item.getEngine().contains("oracle")) {
+                if(enabled && item.getEngine().contains("oracle")) {
                     // need to get the oracle SSL port from the associated option group
                     logger.info("determining SSL port for Oracle DB " + item.getDBInstanceIdentifier() + " (" + item.getEngine() + ")");
                     List<String> optionGroups = item.getOptionGroupMemberships().stream()
@@ -127,45 +203,126 @@ public class RdsLookupService {
                     logger.info("The SSL Port for " + item.getDBName() + " is: " + port);
                 }
 
-                if(item.getReadReplicaSourceDBInstanceIdentifier() != null){
+                if(enabled && item.getReadReplicaSourceDBInstanceIdentifier() != null){
                     status = "Unsupported (Read-Only replica of " +item.getReadReplicaSourceDBInstanceIdentifier() + ")";
+                    enabled = false;
                 }
-                if(!enabled){
-                    status = "Missing Gatekeeper RDS support Security Group";
-                }else{
+                if(enabled){
                     //if enabled lets check if the DB is working
-
                     try {
-
-                        String dbStatus = databaseConnectionService.checkDb(item.getEngine(), getAddress(item.getEndpoint().getAddress(),String.valueOf(port),dbName));
+                        String dbStatus = databaseConnectionService.checkDb(item.getEngine(), address);
                         status = !dbStatus.isEmpty() ? dbStatus : status;
+                        enabled = dbStatus.isEmpty(); // if there's no message back from the DB enabled is still true
                     }catch(GKUnsupportedDBException e){
-                        logger.error("Database Engine is not supported", e);
-                        status = "DB Engine not supported";
+                        logger.error(STATUS_UNSUPPORTED_DB_ENGINE, e);
+                        status = STATUS_UNSUPPORTED_DB_ENGINE;
+                        enabled = false;
                     }
                     // if status hasn't changed then get the roles
-                    if(status.equals(item.getDBInstanceStatus())) {
+                    if(enabled && status.equals(item.getDBInstanceStatus())) {
                         // get available roles for DB
                         try {
-                            availableRoles = databaseConnectionService.getAvailableRolesForDb(item.getEngine(), getAddress(item.getEndpoint().getAddress(), String.valueOf(port), dbName));
+                            availableRoles = databaseConnectionService.getAvailableRolesForDb(item.getEngine(), address);
                             Collections.sort(availableRoles);
                             logger.info("Found the following roles on " + item.getDBInstanceIdentifier() + " (" + availableRoles +").");
                         } catch (Exception e) {
-                            logger.error("Could not fetch roles available to DB", e);
-                            status = "Could not fetch roles available to DB";
+                            logger.error(STATUS_COULD_NOT_FETCH_ROLES, e);
+                            if(e.getMessage().contains("password")){
+                                status = STATUS_UNABLE_TO_LOGIN;
+                            }else {
+                                status = STATUS_COULD_NOT_FETCH_ROLES;
+                            }
+                            enabled = false;
                         }
                     }
                 }
-
-                gatekeeperRDSInstances.add(new GatekeeperRDSInstance(item.getDbiResourceId(), item.getDBInstanceIdentifier(),
-                        dbName != null ? dbName : "", item.getEngine(), status,
-                        item.getDBInstanceArn(), item.getEndpoint().getAddress() + ":" + port, application, availableRoles, enabled));
             }
+
+            gatekeeperRDSInstances.add(new GatekeeperRDSInstance(item.getDbiResourceId(), item.getDBInstanceIdentifier(),
+                    dbName != null ? dbName : "", item.getEngine(), status,
+                    item.getDBInstanceArn(), item.getEndpoint().getAddress() + ":" + port, application, availableRoles, enabled));
         });
 
         return gatekeeperRDSInstances;
     }
 
+    /**
+     * This looks at database clusters for Aurora, similar to the function loadToGatekeeperRDSInstance() but the difference
+     * being we have to look at the cluster as a whole vs the single instance
+     */
+    private List<GatekeeperRDSInstance> loadToGatekeeperRDSInstanceAurora(AmazonRDSClient client, List<DBCluster> instances, List<String> securityGroupIds){
+        ArrayList<GatekeeperRDSInstance> gatekeeperRDSInstances = new ArrayList<>();
+
+        instances.forEach(item -> {
+            String application = getApplicationTagforInstanceArn(client, item.getDBClusterArn());
+            boolean enabled = false;
+            String status = item.getStatus();
+            Integer port = item.getPort();
+            List<String> availableRoles = null;
+            String dbName = item.getDatabaseName();
+            String address = getAddress(item.getEndpoint(),String.valueOf(port),dbName);
+
+            if(item.getStatus().equalsIgnoreCase(STATUS_AVAILABLE)
+                    || item.getStatus().equalsIgnoreCase(STATUS_BACKING_UP)) {
+                enabled = item.getVpcSecurityGroups().stream()
+                        .anyMatch(sg -> {
+                            return securityGroupIds.contains(sg.getVpcSecurityGroupId());
+                        });
+
+                if(!enabled){
+                    status = STATUS_MISSING_SGS;
+                }
+
+                if(enabled && item.getReplicationSourceIdentifier() != null){
+                    status = "Unsupported (Read-Only replica of " + item.getReplicationSourceIdentifier() + ")";
+                    enabled = false;
+                }
+
+                //if the cluster does not have any instances associated then it won't be able to work with Gatekeeper
+                if(enabled && item.getDBClusterMembers().size() < 1){
+                    status = STATUS_NO_INSTANCES;
+                    enabled = false;
+                } else if(enabled && item.getDBClusterMembers().stream().noneMatch(DBClusterMember::isClusterWriter)){
+                    //if the cluster has no writer instances associated with it. Gatekeeper cannot create the user
+                    status = STATUS_NO_WRITERS;
+                    enabled = false;
+                }
+
+                if(enabled) {
+                    try {
+                        String dbStatus = databaseConnectionService.checkDb(item.getEngine(), address);
+                        status = !dbStatus.isEmpty() ? dbStatus : status;
+                        enabled = dbStatus.isEmpty(); // if there's no message back from the DB enabled is still true
+                    }catch(GKUnsupportedDBException e){
+                        logger.error(STATUS_UNSUPPORTED_DB_ENGINE, e);
+                        status = STATUS_UNSUPPORTED_DB_ENGINE;
+                        enabled = false;
+                    }
+
+                    if(enabled){
+                        // get available roles for DB
+                        try {
+                            availableRoles = databaseConnectionService.getAvailableRolesForDb(item.getEngine(), address);
+                            Collections.sort(availableRoles);
+                            logger.info("Found the following roles on " + item.getDBClusterIdentifier() + " (" + availableRoles +").");
+                        } catch (Exception e) {
+                            logger.error(STATUS_COULD_NOT_FETCH_ROLES, e);
+                            if (e.getMessage().contains("password")) {
+                                status = STATUS_UNABLE_TO_LOGIN;
+                            } else {
+                                status = STATUS_COULD_NOT_FETCH_ROLES;
+                            }
+                            enabled = false;
+                        }
+                    }
+                }
+            }
+            gatekeeperRDSInstances.add(new GatekeeperRDSInstance(item.getDbClusterResourceId(), item.getDBClusterIdentifier(),
+                    dbName, item.getEngine(), status, item.getDBClusterArn(), item.getEndpoint() + ":" + port, application, availableRoles, enabled));
+        });
+
+        return gatekeeperRDSInstances;
+    }
     private String getAddress(String address, String port, String dbName){
         return String.format("%s:%s/%s", address, port, dbName);
     }
@@ -198,41 +355,32 @@ public class RdsLookupService {
         return gatekeeperRDSInstances;
     }
 
-    public Optional<GatekeeperRDSInstance> getOneInstance(AWSEnvironment environment, String dbInstanceIdentifier) {
+    private List<GatekeeperRDSInstance> loadInstancesAurora(AWSEnvironment environment, Predicate<? super DBCluster> filter) {
+        logger.info("Looking up Aurora Clusters");
         Long startTime = System.currentTimeMillis();
-        DescribeDBInstancesRequest describeDBInstancesRequest = new DescribeDBInstancesRequest();
+        DescribeDBClustersRequest describeDBClustersRequest = new DescribeDBClustersRequest();
         List<String> securityGroupIds = sgLookupService.fetchSgsForAccountRegion(environment);
         AmazonRDSClient amazonRDSClient = awsSessionService.getRDSSession(environment);
-        DescribeDBInstancesResult result = amazonRDSClient.describeDBInstances(describeDBInstancesRequest.withDBInstanceIdentifier(dbInstanceIdentifier));
+        DescribeDBClustersResult result = amazonRDSClient.describeDBClusters(describeDBClustersRequest);
 
-        List<GatekeeperRDSInstance> gatekeeperRDSInstances = loadToGatekeeperRDSInstance(amazonRDSClient, result.getDBInstances(), securityGroupIds);
+        List<GatekeeperRDSInstance> gatekeeperRDSInstances = loadToGatekeeperRDSInstanceAurora(amazonRDSClient,
+                result.getDBClusters()
+                        .stream()
+                        .filter(filter)
+                        .collect(Collectors.toList()), securityGroupIds);
 
-        logger.info("Fetched Instance in " + ((double)(System.currentTimeMillis() - startTime) / 1000) + " Seconds");
-
-        Optional<GatekeeperRDSInstance> gatekeeperRDSInstance = Optional.of(gatekeeperRDSInstances.get(0));
-        return gatekeeperRDSInstance;
-    }
-
-    public Map<RoleType, List<String>> getSchemasForInstance(AWSEnvironment environment, String instanceId) throws Exception{
-        logger.info("Getting Schema info for " + instanceId + " On Account " + environment.getAccount() + " and Region " + environment.getRegion());
-        Optional<GatekeeperRDSInstance> instance = getOneInstance(environment, instanceId);
-        if(instance.isPresent()){
-            return databaseConnectionService.getAvailableSchemasForDb(instance.get());
-        }else{
-            return unavailableMap();
+        //At a certain point (Usually ~100 instances) amazon starts paging the rds results, so we need to get each page, which is keyed off by a marker.
+        while(result.getMarker() != null) {
+            result = amazonRDSClient.describeDBClusters(describeDBClustersRequest.withMarker(result.getMarker()));
+            gatekeeperRDSInstances.addAll(loadToGatekeeperRDSInstanceAurora(amazonRDSClient,
+                    result.getDBClusters()
+                            .stream()
+                            .filter(filter)
+                            .collect(Collectors.toList()), securityGroupIds));
         }
-    }
+        logger.info("Refreshed instance data in " + ((double)(System.currentTimeMillis() - startTime) / 1000) + " Seconds");
 
-    @PreAuthorize("@gatekeeperRoleService.isApprover()")
-    public List<DbUser> getUsersForInstance(AWSEnvironment environment, String instanceName) throws Exception {
-        Optional<GatekeeperRDSInstance> instance = getOneInstance(environment, instanceName);
-
-        if(instance.isPresent()){
-            return databaseConnectionService.getUsersForDb(instance.get());
-        }else{
-            logger.error("Could not find database with " + instanceName + " on account " + environment.getAccount() + "(" + environment.getRegion() + ")");
-            return Collections.emptyList();
-        }
+        return gatekeeperRDSInstances;
     }
 
     private Map<RoleType, List<String>> unavailableMap(){

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/LookupType.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/LookupType.java
@@ -14,21 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.finra.gatekeeper.services.aws.model;
 
-import SearchableDataService from './generic/SearchableDataService';
-
-/**
- * The Service to make AWS Calls
- * @returns {{}}
- *
- */
-
-class SchemaDataService extends SearchableDataService{
-    constructor($http,$state){
-        super($http,$state);
-        this.resource = 'getAvailableSchemas';
-        this.params= ['account','region','instanceId', "instanceName"];
-    }
+public enum LookupType {
+    RDS, AURORA
 }
-
-export default SchemaDataService;

--- a/services/rds/src/main/resources/application.yml
+++ b/services/rds/src/main/resources/application.yml
@@ -97,6 +97,8 @@ gatekeeper:
     supportedDbs:
       mysql: mySQLDBConnection
       postgres: postgresDBConnection
+      aurora-mysql: mySQLDBConnection
+      aurora-postgresql: postgresDBConnection
     assumeMinServerVersion: assumeMinServerVersion=9.4
     sslParams: ssl=${gatekeeper.db.ssl}&sslmode=${gatekeeper.db.sslMode}&sslrootcert=${gatekeeper.db.sslCert}
     postgres:

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/aws/RdsLookupServiceTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/aws/RdsLookupServiceTest.java
@@ -1,0 +1,446 @@
+/*
+ *
+ * Copyright 2018. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finra.gatekeeper.services.aws;
+
+import com.amazonaws.services.rds.AmazonRDSClient;
+import com.amazonaws.services.rds.model.*;
+import org.finra.gatekeeper.configuration.GatekeeperProperties;
+import org.finra.gatekeeper.rds.exception.GKUnsupportedDBException;
+import org.finra.gatekeeper.services.aws.model.AWSEnvironment;
+import org.finra.gatekeeper.services.aws.model.GatekeeperRDSInstance;
+import org.finra.gatekeeper.services.db.DatabaseConnectionService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.*;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class RdsLookupServiceTest {
+
+    @Mock
+    private AwsSessionService awsSessionService;
+    @Mock
+    private DatabaseConnectionService databaseConnectionService;
+    @Mock
+    private SGLookupService sgLookupService;
+    private GatekeeperProperties gatekeeperProperties;
+    @Mock
+    private AmazonRDSClient amazonRDSClient;
+
+    private RdsLookupService rdsLookupService;
+    private AWSEnvironment test;
+
+    private final String RDS_ENGINE_PG = "postgres";
+    private final String RDS_ENGINE_ORACLE = "oracle";
+    private final String AURORA_ENGINE = "aurora-postgresql";
+    private final String APP_IDENTITY = "Application";
+    private final String STATUS_AVAILABLE = "available";
+    private final String STATUS_STOPPED = "stopped";
+    private final String SG_ONE = "sg-123";
+    private final String SG_TWO = "sg-456";
+    private final String DB_NAME = "postgres";
+    private final Integer DB_PORT = 5432;
+    private final List<String> roles = Arrays.asList("gk_readonly", "gk_datafix", "gk_dba");
+
+    @Before
+    public void setUp() throws Exception {
+        gatekeeperProperties = new GatekeeperProperties()
+                .setAppIdentityTag(APP_IDENTITY);
+        rdsLookupService = new RdsLookupService(awsSessionService, databaseConnectionService, sgLookupService, gatekeeperProperties);
+        test = new AWSEnvironment("test", "test");
+
+        Mockito.when(awsSessionService.getRDSSession(test)).thenReturn(amazonRDSClient);
+
+        //RDS
+        Mockito.when(amazonRDSClient.describeDBInstances(Mockito.any())).thenReturn(initializeInstances());
+        Mockito.when(amazonRDSClient.describeOptionGroups(Mockito.any())).thenReturn(new DescribeOptionGroupsResult()
+                .withOptionGroupsList(
+                        new OptionGroup()
+                                .withOptionGroupName("test-og")
+                                .withOptions(new Option().withOptionName("SSL").withPort(1234))));
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(RDS_ENGINE_PG), Mockito.contains("instance"))).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(RDS_ENGINE_ORACLE), Mockito.contains("instance"))).thenReturn("");
+        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(RDS_ENGINE_PG), Mockito.contains("instance"))).thenReturn(roles);
+        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(RDS_ENGINE_ORACLE), Mockito.contains("instance"))).thenReturn(roles);
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq("sqlserver"), Mockito.contains("unsupported"))).thenThrow(new GKUnsupportedDBException("Unsupported DB"));
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(RDS_ENGINE_PG), Mockito.contains("missing"))).thenReturn("gatekeeper user missing createrole");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(RDS_ENGINE_PG), Mockito.contains("rolesfailunable"))).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(RDS_ENGINE_PG), Mockito.contains("rolesfailpassword"))).thenReturn("");
+        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(RDS_ENGINE_PG), Mockito.contains("rolesfailunable"))).thenThrow(new Exception("Unable to get roles"));
+        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(RDS_ENGINE_PG), Mockito.contains("rolesfailpassword"))).thenThrow(new Exception("Unable to login: password authentication failed"));
+
+        //AURORA
+        Mockito.when(amazonRDSClient.describeDBClusters(Mockito.any())).thenReturn(initializeClusters());
+        Mockito.when(amazonRDSClient.listTagsForResource(Mockito.any())).thenReturn(initializeTags());
+        Mockito.when(sgLookupService.fetchSgsForAccountRegion(test)).thenReturn(Arrays.asList(SG_ONE, SG_TWO));
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("dbendpoint"))).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("rolesfailunable"))).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("rolesfailpassword"))).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("unsupported"))).thenThrow(new GKUnsupportedDBException("Unsupported DB"));
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("missing"))).thenReturn("gatekeeper user missing createrole");
+        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("dbendpoint"))).thenReturn(roles);
+        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("rolesfailunable"))).thenThrow(new Exception("Unable to get roles"));
+        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("rolesfailpassword"))).thenThrow(new Exception("Unable to login: password authentication failed"));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void unsupportedTestGetInstancesFilter(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "zzz", "gk");
+        Assert.assertEquals(0, instances.size());
+    }
+
+    @Test
+    public void rdsTestGetInstancesFilter(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "RDS", "gk");
+        Assert.assertEquals(8, instances.size());
+        instances = rdsLookupService.getInstances(test, "RDS", "gk-A");
+        Assert.assertEquals(1, instances.size());
+        instances = rdsLookupService.getInstances(test, "RDS", "gk-B");
+        Assert.assertEquals(0, instances.size());
+    }
+
+    @Test
+    public void rdsTestGetInstancesHappy(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "RDS", "gk-A");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertTrue(instance.getEnabled());
+        Assert.assertEquals("TEST", instance.getApplication());
+        Assert.assertEquals("available", instance.getStatus());
+        Assert.assertEquals(new HashSet<>(Arrays.asList("gk_readonly","gk_datafix","gk_dba")), new HashSet<>(instance.getAvailableRoles()));
+    }
+
+    @Test
+    public void rdsTestGetInstancesMissingSgs(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "RDS", "gk-C");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals(RdsLookupService.STATUS_MISSING_SGS, instance.getStatus());
+        Assert.assertFalse(instance.getEnabled());
+    }
+
+    @Test
+    public void rdsTestGetInstancesMissingReadReplica(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "RDS", "gk-D");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals("Unsupported (Read-Only replica of replica1)", instance.getStatus());
+        Assert.assertFalse(instance.getEnabled());
+    }
+
+    @Test
+    public void rdsTestGetInstancesUnsupported(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "RDS", "gk-E");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals(RdsLookupService.STATUS_UNSUPPORTED_DB_ENGINE, instance.getStatus());
+        Assert.assertFalse(instance.getEnabled());
+    }
+
+    @Test
+    public void rdsTestGetInstanceMisconfiguredUser(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "RDS", "gk-F");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals("gatekeeper user missing createrole", instance.getStatus());
+        Assert.assertFalse(instance.getEnabled());
+    }
+
+    @Test
+    public void rdsTestGetInstanceCantGetRoles(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "RDS", "gk-G");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals(RdsLookupService.STATUS_COULD_NOT_FETCH_ROLES, instance.getStatus());
+        Assert.assertFalse(instance.getEnabled());
+    }
+
+    @Test
+    public void rdsTestGetInstanceCantLogin(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "RDS", "gk-H");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals(RdsLookupService.STATUS_UNABLE_TO_LOGIN, instance.getStatus());
+        Assert.assertFalse(instance.getEnabled());
+    }
+
+    @Test
+    public void rdsTestGetInstanceOracle(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "RDS", "gk-I");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals("TEST", instance.getApplication());
+        Assert.assertEquals("available", instance.getStatus());
+        Assert.assertEquals(new HashSet<>(Arrays.asList("gk_readonly","gk_datafix","gk_dba")), new HashSet<>(instance.getAvailableRoles()));
+        Assert.assertEquals("instance5:1234", instance.getEndpoint());
+    }
+
+    //AURORA
+    @Test
+    public void auroraTestGetInstancesFilter(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "AURORA", "gk");
+        Assert.assertEquals(10, instances.size());
+        instances = rdsLookupService.getInstances(test, "AURORA", "gk-A");
+        Assert.assertEquals(1, instances.size());
+        instances = rdsLookupService.getInstances(test, "AURORA", "cluster-gk2");
+        Assert.assertEquals(1, instances.size());
+        instances = rdsLookupService.getInstances(test, "AURORA", "clusta-gk2");
+        Assert.assertEquals(0, instances.size());
+    }
+
+    @Test
+    public void auroraTestGetInstancesHappy(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "AURORA", "gk-A");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertTrue(instance.getEnabled());
+        Assert.assertEquals("TEST", instance.getApplication());
+        Assert.assertEquals("available", instance.getStatus());
+        Assert.assertEquals(new HashSet<>(Arrays.asList("gk_readonly","gk_datafix","gk_dba")), new HashSet<>(instance.getAvailableRoles()));
+    }
+
+    @Test
+    public void auroraTestGetInstancesReadReplica(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "AURORA", "gk-C");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals("Unsupported (Read-Only replica of replica1)", instance.getStatus());
+        Assert.assertFalse(instance.getEnabled());
+    }
+
+    @Test
+    public void auroraTestGetInstancesStopped(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "AURORA", "gk-B");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals(STATUS_STOPPED, instance.getStatus());
+        Assert.assertFalse(instance.getEnabled());
+    }
+
+    @Test
+    public void auroraTestGetInstancesMissingSgs(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "AURORA", "gk-D");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals(RdsLookupService.STATUS_MISSING_SGS, instance.getStatus());
+        Assert.assertFalse(instance.getEnabled());
+    }
+
+    @Test
+    public void auroraTestGetInstancesEmptyCluster(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "AURORA", "gk-E");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals(RdsLookupService.STATUS_NO_INSTANCES, instance.getStatus());
+        Assert.assertFalse(instance.getEnabled());
+    }
+
+    @Test
+    public void auroraTestGetInstancesNoWriters(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "AURORA", "gk-F");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals(RdsLookupService.STATUS_NO_WRITERS, instance.getStatus());
+        Assert.assertFalse(instance.getEnabled());
+    }
+
+    @Test
+    public void auroraTestGetInstanceUnsupported(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "AURORA", "gk-G");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals(RdsLookupService.STATUS_UNSUPPORTED_DB_ENGINE, instance.getStatus());
+        Assert.assertFalse(instance.getEnabled());
+    }
+
+    @Test
+    public void auroraTestGetInstanceMisconfiguredUser(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "AURORA", "gk-H");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals("gatekeeper user missing createrole", instance.getStatus());
+        Assert.assertFalse(instance.getEnabled());
+    }
+
+    @Test
+    public void auroraTestGetInstanceCantGetRoles(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "AURORA", "gk-I");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals(RdsLookupService.STATUS_COULD_NOT_FETCH_ROLES, instance.getStatus());
+        Assert.assertFalse(instance.getEnabled());
+    }
+
+    @Test
+    public void auroraTestGetInstanceCantLogin(){
+        List<GatekeeperRDSInstance> instances;
+
+        instances = rdsLookupService.getInstances(test, "AURORA", "gk-J");
+        Assert.assertEquals(1, instances.size());
+        GatekeeperRDSInstance instance = instances.get(0);
+        Assert.assertEquals(RdsLookupService.STATUS_UNABLE_TO_LOGIN, instance.getStatus());
+        Assert.assertFalse(instance.getEnabled());
+    }
+
+    @Test
+    public void rdsTestGetOneInstance(){
+        Mockito.when(amazonRDSClient.describeDBInstances(Mockito.any())).thenReturn(
+                new DescribeDBInstancesResult().withDBInstances(
+                        initializeInstance("instance1", RDS_ENGINE_PG, "gk-A-instance", "db-gk1", STATUS_AVAILABLE, SG_ONE, null)));
+        Optional<GatekeeperRDSInstance> instance = rdsLookupService.getOneInstance(test, "gk-A-instance", "gk-A-instance");
+        Assert.assertTrue(instance.isPresent());
+        Assert.assertEquals("TEST", instance.get().getApplication());
+        Assert.assertEquals("available", instance.get().getStatus());
+        Assert.assertEquals(new HashSet<>(Arrays.asList("gk_readonly","gk_datafix","gk_dba")), new HashSet<>(instance.get().getAvailableRoles()));
+    }
+
+    @Test
+    public void auroraTestGetOneInstance(){
+        Mockito.when(amazonRDSClient.describeDBClusters(Mockito.any())).thenReturn(
+                new DescribeDBClustersResult().withDBClusters(
+                        initializeCluster("dbendpoint1", "gk-A-cluster", "cluster-gk1", STATUS_AVAILABLE, SG_ONE, null, 2, true))
+        );
+        Optional<GatekeeperRDSInstance> instance = rdsLookupService.getOneInstance(test, "cluster-gk1", "gk-A-cluster");
+        Assert.assertTrue(instance.isPresent());
+        Assert.assertEquals("TEST", instance.get().getApplication());
+        Assert.assertEquals("available", instance.get().getStatus());
+        Assert.assertEquals(new HashSet<>(Arrays.asList("gk_readonly","gk_datafix","gk_dba")), new HashSet<>(instance.get().getAvailableRoles()));
+    }
+
+    private DescribeDBInstancesResult initializeInstances(){
+        return new DescribeDBInstancesResult().withDBInstances(Arrays.asList(
+                initializeInstance("instance1", RDS_ENGINE_PG, "gk-A-instance", "db-gk1", STATUS_AVAILABLE, SG_ONE, null),
+                initializeInstance("instance2", AURORA_ENGINE, "gk-B-instance", "db-gk2", STATUS_AVAILABLE, SG_ONE, null),
+                initializeInstance("instance3", RDS_ENGINE_PG, "gk-C-instance", "db-gk3", STATUS_AVAILABLE, "gk-unsupport", null),
+                initializeInstance("instance4", RDS_ENGINE_PG, "gk-D-instance", "db-gk4", STATUS_AVAILABLE, SG_ONE, "replica1"),
+                initializeInstance("unsupported", "sqlserver", "gk-E-instance", "db-gk5", STATUS_AVAILABLE, SG_TWO, null),
+                initializeInstance("missing", RDS_ENGINE_PG, "gk-F-instance", "db-gk6", STATUS_AVAILABLE, SG_TWO, null),
+                initializeInstance("rolesfailunable", RDS_ENGINE_PG, "gk-G-instance", "db-gk7", STATUS_AVAILABLE, SG_TWO, null),
+                initializeInstance("rolesfailpassword", RDS_ENGINE_PG, "gk-H-instance", "db-gk8", STATUS_AVAILABLE, SG_TWO, null),
+                initializeInstance("instance5", RDS_ENGINE_ORACLE, "gk-I-instance", "db-gk9", STATUS_AVAILABLE, SG_TWO, null)
+        ));
+    }
+
+    private DescribeDBClustersResult initializeClusters(){
+        return new DescribeDBClustersResult().withDBClusters(Arrays.asList(
+                initializeCluster("dbendpoint1", "gk-A-cluster", "cluster-gk1", STATUS_AVAILABLE, SG_ONE, null, 2, true),
+                initializeCluster("dbendpoint2", "gk-B-cluster", "cluster-gk2", STATUS_STOPPED, SG_ONE, null, 1, true),
+                initializeCluster("dbendpoint3", "gk-C-cluster", "cluster-gk3", STATUS_AVAILABLE, SG_TWO, "replica1", 1, true),
+                initializeCluster("dbendpoint4", "gk-D-cluster", "cluster-gk4", STATUS_AVAILABLE, "gk-unsupportedsg", null, 3, true),
+                initializeCluster("dbendpoint5", "gk-E-cluster", "cluster-gk5", STATUS_AVAILABLE, SG_TWO, null, 0, true),
+                initializeCluster("dbendpoint6", "gk-F-cluster", "cluster-gk6", STATUS_AVAILABLE, SG_ONE, null, 2, false),
+                initializeCluster("unsupported", "gk-G-cluster", "cluster-gk7", STATUS_AVAILABLE, SG_ONE, null, 2, true),
+                initializeCluster("missing", "gk-H-cluster", "cluster-gk8", STATUS_AVAILABLE, SG_ONE, null, 2, true),
+                initializeCluster("rolesfailunable", "gk-I-cluster", "cluster-gk9", STATUS_AVAILABLE, SG_ONE, null, 2, true),
+                initializeCluster("rolesfailpassword", "gk-J-cluster", "cluster-gk10", STATUS_AVAILABLE, SG_ONE, null, 2, true)
+        ));
+    }
+
+    private DBInstance initializeInstance(String endpoint, String engine, String instanceId, String dbiResourceId, String status, String sg, String readreplica){
+        return new DBInstance()
+                .withEndpoint(new Endpoint()
+                        .withAddress(endpoint)
+                        .withPort(9999))
+                .withEngine(engine)
+                .withDBName("postgres")
+                .withDBInstanceIdentifier(instanceId)
+                .withDbiResourceId(dbiResourceId)
+                .withDBInstanceStatus(status)
+                .withVpcSecurityGroups(
+                        new VpcSecurityGroupMembership()
+                            .withVpcSecurityGroupId(sg)
+                )
+                .withReadReplicaSourceDBInstanceIdentifier(readreplica)
+                .withOptionGroupMemberships(
+                        new OptionGroupMembership().withOptionGroupName("test-og")
+                );
+    }
+
+    private DBCluster initializeCluster(String endpoint, String clusterId, String clusterResourceId, String status, String sg, String readreplica, int numInstances, boolean hasWriter){
+        List<DBClusterMember> members = new ArrayList<>();
+        for(int i = 0; i < numInstances; i++){
+            members.add(new DBClusterMember().withDBInstanceIdentifier("member"+i).withIsClusterWriter(i == 1 && hasWriter));
+        }
+
+        return new DBCluster().withEndpoint(endpoint)
+                .withEngine(AURORA_ENGINE)
+                .withDBClusterIdentifier(clusterId)
+                .withDbClusterResourceId(clusterResourceId)
+                .withDatabaseName("postgres")
+                .withPort(5432)
+                .withStatus(status)
+                .withVpcSecurityGroups(
+                        new VpcSecurityGroupMembership()
+                                .withVpcSecurityGroupId(sg)
+                )
+                .withDBClusterMembers(members)
+                .withReplicationSourceIdentifier(readreplica);
+
+    }
+    private ListTagsForResourceResult initializeTags(){
+        return new ListTagsForResourceResult().withTagList(
+                new Tag().withKey(APP_IDENTITY)
+                        .withValue("TEST"));
+    }
+}

--- a/ui/app/component/rds/admin/RdsAdminController.js
+++ b/ui/app/component/rds/admin/RdsAdminController.js
@@ -98,6 +98,7 @@ class RdsAdminController extends GatekeeperAdminController{
             {
                 account: vm.forms.awsInstanceForm.selectedAccount.alias.toLowerCase(),
                 region: vm.forms.awsInstanceForm.selectedRegion.name,
+                instanceId: row.instanceId,
                 instanceName: row.name,
             });
 
@@ -119,6 +120,7 @@ class RdsAdminController extends GatekeeperAdminController{
                 vm.blocking = true;
                 vm.usersTable.promise = vm[REVOKE].delete(vm.forms.awsInstanceForm.selectedAccount.alias.toLowerCase(),
                     vm.forms.awsInstanceForm.selectedRegion.name,
+                    vm.selectedItems[0].instanceId,
                     vm.selectedItems[0].name,
                     vm.usersTable.selected);
 

--- a/ui/app/component/rds/selfservice/GkRdsSearch.js
+++ b/ui/app/component/rds/selfservice/GkRdsSearch.js
@@ -39,6 +39,7 @@ class GkRdsSearch extends Directive{
 
     controller($scope, $mdDialog, gkRDSService, gkAccountService){
         let vm = this;
+        vm.types = ['RDS', 'Aurora'];
         vm.rdsService = gkRDSService;
         gkAccountService.fetch().then((response) =>{
             vm.awsAccounts = response.data;
@@ -113,6 +114,7 @@ class GkRdsSearch extends Directive{
                 vm.awsTable.data.splice(0, vm.awsTable.data.length);
                 vm.awsTable.promise = vm.rdsService.search(
                     {
+                        type: vm.forms.awsInstanceForm.selectedType,
                         account: vm.forms.awsInstanceForm.selectedAccount.alias.toLowerCase(),
                         region: vm.forms.awsInstanceForm.selectedRegion.name,
                         searchText:vm.forms.awsInstanceForm.searchText,

--- a/ui/app/component/rds/selfservice/RdsSchemaDialogController.js
+++ b/ui/app/component/rds/selfservice/RdsSchemaDialogController.js
@@ -34,7 +34,7 @@ class RdsSchemaDialogController {
         this[DIALOG] = $mdDialog;
 
         vm.fetched = false;
-        vm.schemaPromise = gkSchemaService.search({account:account.alias, region: region.name, instanceId: database.name});
+        vm.schemaPromise = gkSchemaService.search({account:account.alias, region: region.name, instanceName: database.name, instanceId: database.instanceId});
         vm.schemaPromise.then((response) => {
             vm.schemas = response.data;
             vm.fetched = true;

--- a/ui/app/component/rds/selfservice/template/gatekeeperAWSRdsComponent.tpl.html
+++ b/ui/app/component/rds/selfservice/template/gatekeeperAWSRdsComponent.tpl.html
@@ -21,6 +21,14 @@
         <form name="ctrl.forms.awsInstanceForm" layout="row">
             <div layout="column">
                 <md-input-container md-no-float>
+                    <label>Select a Type</label>
+                    <md-select ng-model="ctrl.forms.awsInstanceForm.selectedType" ng-change="ctrl.clearInstances()" required>
+                        <md-option ng-value="opt" ng-repeat="opt in ctrl.types">{{ opt }}</md-option>
+                    </md-select>
+                </md-input-container>
+            </div>
+            <div layout="column">
+                <md-input-container md-no-float>
                     <label>Select an Account</label>
                     <md-select ng-model="ctrl.forms.awsInstanceForm.selectedAccount" ng-change="ctrl.clearInstances()" required>
                         <md-option ng-value="opt" ng-repeat="opt in ctrl.awsAccounts | orderBy:['grouping','alias']">{{ opt.alias }}</md-option>
@@ -43,7 +51,7 @@
             </div>
             <div layout="column" layout-align="center center">
                 <button md-button type="submit" class="md-raised md-primary"
-                        ng-disabled="(!ctrl.forms.awsInstanceForm.selectedAccount || !ctrl.forms.awsInstanceForm.selectedRegion && ctrl.forms.awsInstanceForm.$invalid)"
+                        ng-disabled="(!ctrl.forms.awsInstanceForm.selectedType || !ctrl.forms.awsInstanceForm.selectedAccount || !ctrl.forms.awsInstanceForm.selectedRegion && ctrl.forms.awsInstanceForm.$invalid)"
                         ng-click="ctrl.searchRDSInstances()"> Search </button>
             </div>
         </form>

--- a/ui/app/component/shared/RDSDataService.js
+++ b/ui/app/component/shared/RDSDataService.js
@@ -28,7 +28,7 @@ class RDSDataService extends SearchableDataService{
     constructor($http,$state){
         super($http,$state);
         this.resource = 'searchDBInstances';
-        this.params= ['account','region','searchText'];
+        this.params= ['type','account','region','searchText'];
     }
 }
 

--- a/ui/app/component/shared/RdsRevokeUsersDataService.js
+++ b/ui/app/component/shared/RdsRevokeUsersDataService.js
@@ -29,11 +29,12 @@ class RdsRevokeUsersDataService extends DataService{
         this.resource = 'db/removeUsers';
     }
 
-    delete(account, region, instanceName, users){
+    delete(account, region, instanceId, instanceName, users){
         let bundle = {
             account: account,
             region: region,
-            db: instanceName,
+            instanceId: instanceId,
+            instanceName: instanceName,
             users: users,
         };
 

--- a/ui/app/component/shared/RdsUsersDataService.js
+++ b/ui/app/component/shared/RdsUsersDataService.js
@@ -27,7 +27,7 @@ class RdsUsersDataService extends SearchableDataService{
     constructor($http,$state){
         super($http,$state);
         this.resource = 'getUsers';
-        this.params= ['account','region','instanceName'];
+        this.params= ['account','region','instanceId','instanceName'];
     }
 
 }

--- a/ui/test/unit/specs/rdsadmin.component.spec.js
+++ b/ui/test/unit/specs/rdsadmin.component.spec.js
@@ -148,13 +148,14 @@ describe('GateKeeper RDS admin component', function () {
                    selectedAccount: { alias:'ut'},
                    selectedRegion: { name:'us-east-1'}
                };
-               let row = {name:'testid'};
+               let row = {name:'testid', instanceId: 'testInstanceId'};
                controller.getUsers(row);
                usersDeferred.resolve(resp);
                scope.$apply();
                expect(gkRdsUserService.search).toHaveBeenCalledWith({
                    account:controller.forms.awsInstanceForm.selectedAccount.alias,
                    region:controller.forms.awsInstanceForm.selectedRegion.name,
+                   instanceId: row.instanceId,
                    instanceName:row.name
                });
                expect(controller.usersTable.data).toEqual(resp.data);


### PR DESCRIPTION
This commit contains both updates to the UI and the RDS service. The RDS service treats aurora instances as a cluster where the traditional non-aurora RDS instances are to remain to be treated as a single instance. Because of this the UI has had a new field added to the RDS Instance search: "Type" which will be one of "RDS" or "Aurora". Any RDS Instance that has an aurora-based engine will not show up in the "RDS" result set, access to these resources will be expected to be requested by using the "Aurora" type.