### PR TITLE
Added a DB Credentials Provider interface to allow users more control over their gatekeeper user passwords

### DIFF
--- a/services/db/src/main/java/org/finra/gatekeeper/rds/interfaces/DBConnection.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/interfaces/DBConnection.java
@@ -18,8 +18,7 @@
 package org.finra.gatekeeper.rds.interfaces;
 
 import org.finra.gatekeeper.rds.exception.GKUnsupportedDBException;
-import org.finra.gatekeeper.rds.model.DbUser;
-import org.finra.gatekeeper.rds.model.RoleType;
+import org.finra.gatekeeper.rds.model.*;
 
 import java.sql.SQLException;
 import java.util.List;
@@ -32,49 +31,60 @@ public interface DBConnection {
     /**
      * Grants user access to a database
      *
-     * @param user
-     * @param password
-     * @param role
-     * @param address
-     * @param time
-     * @return
-     * @throws Exception
+     * @param rdsGrantAccessQuery - the details of the database to grant access to
+     * @return true if success, false if failure
+     * @throws Exception - if connection or query fails on any level
      */
-    boolean grantAccess(String user, String password, RoleType role, String address, String gkUserPassword, Integer time) throws Exception;
+    boolean grantAccess(RdsGrantAccessQuery rdsGrantAccessQuery) throws Exception;
 
     /**
      * Removes user from a database
      *
-     * @param user
-     * @param role
-     * @param address
-     * @return
-     * @throws Exception
+     * @param rdsRevokeAccessQuery - the details of the database to revoke access to
+     * @return true if success, false if failure
+     * @throws Exception - if connection or query fails on any level
      */
-    boolean revokeAccess(String user, RoleType role, String address, String gkUserPassword) throws Exception;
+    boolean revokeAccess(RdsRevokeAccessQuery rdsRevokeAccessQuery) throws Exception;
 
 
-    Map<RoleType, List<String>> getAvailableTables(String address, String gkUserPassword) throws Exception;
+    /**
+     * Gets all of the available tables for the user.
+     *
+     * @param rdsQuery - the details of the database to make the call
+     * @return a Map of RoleType to List of String where the role type corresponds to the tables that they have access to
+     * @throws Exception - if connection or query fails on any level
+     */
+    Map<RoleType, List<String>> getAvailableTables(RdsQuery rdsQuery) throws Exception;
 
     /**
      * Connects to a DB and checks for any required setups
-     * @param address
+     *
+     * @param rdsQuery - the details of the database to make the call
      * @return String - empty if no issues, otherwise will be the issues
      */
-    List<String> checkDb(String address, String gkUserPassword) throws GKUnsupportedDBException;
-
-    List<String> checkIfUsersHasTables(String address, List<String> users, String gkUserPassword) throws SQLException;
+    List<String> checkDb(RdsQuery rdsQuery) throws GKUnsupportedDBException;
 
     /**
-     * Connects to the DB and gets all of the Users currently on the RDS instance
-     * @param address
-     * @return List of all of the users on the instance
+     * Check if the users have any dependent objects
+     *
+     * @param rdsCheckUsersTableQuery - The details of the query for the list of users to check
+     * @return List of the users who have tables
+     * @throws SQLException - if connection or query fails on any level
      */
-    List<DbUser> getUsers(String address, String gkUserPassword) throws SQLException;
+    List<String> checkIfUsersHasTables(RdsCheckUsersTableQuery rdsCheckUsersTableQuery) throws SQLException;
 
     /**
-     * Connects to the DB and gets all of the available gk roles currently on the RDS instance
+     * Connects to the DB and gets all of the Users currently on the RDS database
+     * @param rdsQuery - the details of the database to make the call
+     * @return List of all of the users on the database
      */
-    List<String> getAvailableRoles(String address, String gkUserPassword) throws SQLException;
+    List<DbUser> getUsers(RdsQuery rdsQuery) throws SQLException;
+
+    /**
+     * Connects to the DB and gets all of the available gk roles currently on the RDS database
+     * @param rdsQuery - the details of the database to make the call
+     * @return List of all available roles to that database
+     */
+    List<String> getAvailableRoles(RdsQuery rdsQuery) throws SQLException;
 
 }

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/interfaces/DBConnection.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/interfaces/DBConnection.java
@@ -40,7 +40,7 @@ public interface DBConnection {
      * @return
      * @throws Exception
      */
-    boolean grantAccess(String user, String password, RoleType role, String address, Integer time) throws Exception;
+    boolean grantAccess(String user, String password, RoleType role, String address, String gkUserPassword, Integer time) throws Exception;
 
     /**
      * Removes user from a database
@@ -51,30 +51,30 @@ public interface DBConnection {
      * @return
      * @throws Exception
      */
-    boolean revokeAccess(String user, RoleType role, String address) throws Exception;
+    boolean revokeAccess(String user, RoleType role, String address, String gkUserPassword) throws Exception;
 
 
-    Map<RoleType, List<String>> getAvailableTables(String address) throws Exception;
+    Map<RoleType, List<String>> getAvailableTables(String address, String gkUserPassword) throws Exception;
 
     /**
      * Connects to a DB and checks for any required setups
      * @param address
      * @return String - empty if no issues, otherwise will be the issues
      */
-    List<String> checkDb(String address) throws GKUnsupportedDBException;
+    List<String> checkDb(String address, String gkUserPassword) throws GKUnsupportedDBException;
 
-    List<String> checkIfUsersHasTables(String address, List<String> users) throws SQLException;
+    List<String> checkIfUsersHasTables(String address, List<String> users, String gkUserPassword) throws SQLException;
 
     /**
      * Connects to the DB and gets all of the Users currently on the RDS instance
      * @param address
      * @return List of all of the users on the instance
      */
-    List<DbUser> getUsers(String address) throws SQLException;
+    List<DbUser> getUsers(String address, String gkUserPassword) throws SQLException;
 
     /**
      * Connects to the DB and gets all of the available gk roles currently on the RDS instance
      */
-    List<String> getAvailableRoles(String address) throws SQLException;
+    List<String> getAvailableRoles(String address, String gkUserPassword) throws SQLException;
 
 }

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/interfaces/GKUserCredentialsProvider.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/interfaces/GKUserCredentialsProvider.java
@@ -17,6 +17,8 @@
 
 package org.finra.gatekeeper.rds.interfaces;
 
+import org.finra.gatekeeper.rds.model.RdsQuery;
+
 /**
  * An Interface to provide a custom implementation in which a unique Gatekeeper user's password can be retrieved
  */
@@ -25,11 +27,8 @@ public interface GKUserCredentialsProvider {
     /**
      * Get the secret for the gatekeeper accoount
      *
-     * @param account
-     * @param region
-     * @param sdlc
-     * @param dbName
-     * @return
+     * @param details - The RDS Query being used.
+     * @return - the secret for the given RdsQuery
      */
-    public String getGatekeeperSecret(String account, String region, String sdlc, String dbName);
+    public String getGatekeeperSecret(RdsQuery details);
 }

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/interfaces/GKUserCredentialsProvider.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/interfaces/GKUserCredentialsProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.finra.gatekeeper.rds.interfaces;
+
+/**
+ * An Interface to provide a custom implementation in which a unique Gatekeeper user's password can be retrieved
+ */
+public interface GKUserCredentialsProvider {
+
+    /**
+     * Get the secret for the gatekeeper accoount
+     *
+     * @param account
+     * @param region
+     * @param sdlc
+     * @param dbName
+     * @return
+     */
+    public String getGatekeeperSecret(String account, String region, String sdlc, String dbName);
+}

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsCheckUsersTableQuery.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsCheckUsersTableQuery.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.finra.gatekeeper.rds.model;
+
+import java.util.List;
+
+public class RdsCheckUsersTableQuery extends RdsQuery {
+    /**
+     * The list of users to check
+     */
+    private List<String> users;
+
+    public List<String> getUsers() {
+        return users;
+    }
+
+    public RdsCheckUsersTableQuery withUsers(List<String> users) {
+        this.users = users;
+        return this;
+    }
+
+    public RdsCheckUsersTableQuery(String account, String accountId, String region, String sdlc, String address, String dbName) {
+        super(account, accountId, region, sdlc, address, dbName);
+    }
+
+    public RdsCheckUsersTableQuery(String account, String accountId, String region, String sdlc, String address, String dbName, List<String> users) {
+        super(account, accountId, region, sdlc, address, dbName);
+        this.users = users;
+    }
+
+}

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsCheckUsersTableQuery.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsCheckUsersTableQuery.java
@@ -17,6 +17,8 @@
 
 package org.finra.gatekeeper.rds.model;
 
+import com.google.common.base.MoreObjects;
+
 import java.util.List;
 
 public class RdsCheckUsersTableQuery extends RdsQuery {
@@ -34,13 +36,19 @@ public class RdsCheckUsersTableQuery extends RdsQuery {
         return this;
     }
 
-    public RdsCheckUsersTableQuery(String account, String accountId, String region, String sdlc, String address, String dbName) {
-        super(account, accountId, region, sdlc, address, dbName);
+    public RdsCheckUsersTableQuery(String account, String accountId, String region, String sdlc, String address, String dbInstanceName) {
+        super(account, accountId, region, sdlc, address, dbInstanceName);
     }
 
-    public RdsCheckUsersTableQuery(String account, String accountId, String region, String sdlc, String address, String dbName, List<String> users) {
-        super(account, accountId, region, sdlc, address, dbName);
+    public RdsCheckUsersTableQuery(String account, String accountId, String region, String sdlc, String address, String dbInstanceName, List<String> users) {
+        super(account, accountId, region, sdlc, address, dbInstanceName);
         this.users = users;
     }
 
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("users", users)
+                .toString();
+    }
 }

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsCheckUsersTableQuery.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsCheckUsersTableQuery.java
@@ -18,6 +18,7 @@
 package org.finra.gatekeeper.rds.model;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 
 import java.util.List;
 
@@ -50,5 +51,19 @@ public class RdsCheckUsersTableQuery extends RdsQuery {
         return MoreObjects.toStringHelper(this)
                 .add("users", users)
                 .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RdsCheckUsersTableQuery)) return false;
+        if (!super.equals(o)) return false;
+        RdsCheckUsersTableQuery that = (RdsCheckUsersTableQuery) o;
+        return Objects.equal(users, that.users);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(super.hashCode(), users);
     }
 }

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsGrantAccessQuery.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsGrantAccessQuery.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.finra.gatekeeper.rds.model;
+
+public class RdsGrantAccessQuery extends RdsQuery {
+    /**
+     * The user to create
+     */
+    private String user;
+    /**
+     * The password to give the user
+     */
+    private String password;
+
+    /**
+     * The role to give the user
+     */
+    private RoleType role;
+
+    /**
+     * The amount of time for the request
+     */
+    private Integer time;
+
+    public String getUser() {
+        return user;
+    }
+
+    public RdsGrantAccessQuery withUser(String user) {
+        this.user = user;
+        return this;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public RdsGrantAccessQuery withPassword(String password) {
+        this.password = password;
+        return this;
+    }
+
+    public RoleType getRole() {
+        return role;
+    }
+
+    public RdsGrantAccessQuery withRole(RoleType role) {
+        this.role = role;
+        return this;
+    }
+
+    public Integer getTime() {
+        return time;
+    }
+
+    public RdsGrantAccessQuery withTime(Integer time) {
+        this.time = time;
+        return this;
+    }
+
+    public RdsGrantAccessQuery(String account, String accountId, String region, String sdlc, String address, String dbName) {
+        super(account, accountId, region, sdlc, address, dbName);
+    }
+
+    public RdsGrantAccessQuery(String account, String accountId, String region, String sdlc, String address, String dbName, String user, String password, RoleType role, Integer time) {
+        super(account, accountId, region, sdlc, address, dbName);
+        this.user = user;
+        this.password = password;
+        this.role = role;
+        this.time = time;
+    }
+
+}

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsGrantAccessQuery.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsGrantAccessQuery.java
@@ -18,6 +18,7 @@
 package org.finra.gatekeeper.rds.model;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 
 public class RdsGrantAccessQuery extends RdsQuery {
     /**
@@ -95,5 +96,22 @@ public class RdsGrantAccessQuery extends RdsQuery {
                 .add("role", role)
                 .add("time", time)
                 .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RdsGrantAccessQuery)) return false;
+        if (!super.equals(o)) return false;
+        RdsGrantAccessQuery that = (RdsGrantAccessQuery) o;
+        return Objects.equal(user, that.user) &&
+                Objects.equal(password, that.password) &&
+                role == that.role &&
+                Objects.equal(time, that.time);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(super.hashCode(), user, password, role, time);
     }
 }

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsGrantAccessQuery.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsGrantAccessQuery.java
@@ -17,6 +17,8 @@
 
 package org.finra.gatekeeper.rds.model;
 
+import com.google.common.base.MoreObjects;
+
 public class RdsGrantAccessQuery extends RdsQuery {
     /**
      * The user to create
@@ -77,12 +79,21 @@ public class RdsGrantAccessQuery extends RdsQuery {
         super(account, accountId, region, sdlc, address, dbName);
     }
 
-    public RdsGrantAccessQuery(String account, String accountId, String region, String sdlc, String address, String dbName, String user, String password, RoleType role, Integer time) {
-        super(account, accountId, region, sdlc, address, dbName);
+    public RdsGrantAccessQuery(String account, String accountId, String region, String sdlc, String address, String dbInstanceName, String user, String password, RoleType role, Integer time) {
+        super(account, accountId, region, sdlc, address, dbInstanceName);
         this.user = user;
         this.password = password;
         this.role = role;
         this.time = time;
     }
 
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("user", user)
+                .add("password", password)
+                .add("role", role)
+                .add("time", time)
+                .toString();
+    }
 }

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsQuery.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsQuery.java
@@ -17,6 +17,8 @@
 
 package org.finra.gatekeeper.rds.model;
 
+import com.google.common.base.MoreObjects;
+
 public class RdsQuery {
     /**
      * The name of the AWS account
@@ -44,9 +46,9 @@ public class RdsQuery {
     private String address;
 
     /**
-     * The Database's DB name
+     * The Database's Instance name
      */
-    private String dbName;
+    private String dbInstanceName;
 
     public String getAccount() {
         return account;
@@ -93,24 +95,36 @@ public class RdsQuery {
         return this;
     }
 
-    public String getDbName() {
-        return dbName;
+    public String getDbInstanceName() {
+        return dbInstanceName;
     }
 
     public RdsQuery withDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbInstanceName = dbName;
         return this;
     }
 
-    public RdsQuery(String account, String accountId, String region, String sdlc, String address, String dbName) {
+    public RdsQuery(String account, String accountId, String region, String sdlc, String address, String dbInstanceName) {
         this.account = account;
         this.accountId = accountId;
         this.region = region;
         this.sdlc = sdlc;
         this.address = address;
-        this.dbName = dbName;
+        this.dbInstanceName = dbInstanceName;
     }
 
     public RdsQuery() {
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("account", account)
+                .add("accountId", accountId)
+                .add("region", region)
+                .add("sdlc", sdlc)
+                .add("address", address)
+                .add("dbInstanceName", dbInstanceName)
+                .toString();
     }
 }

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsQuery.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsQuery.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.finra.gatekeeper.rds.model;
+
+public class RdsQuery {
+    /**
+     * The name of the AWS account
+     */
+    private String account;
+
+    /**
+     * The AWS account ID
+     */
+    private String accountId;
+
+    /**
+     * The AWS account's region
+     */
+    private String region;
+
+    /**
+     * the AWS account's SDLC
+     */
+    private String sdlc;
+
+    /**
+     * The Database's address
+     */
+    private String address;
+
+    /**
+     * The Database's DB name
+     */
+    private String dbName;
+
+    public String getAccount() {
+        return account;
+    }
+
+    public RdsQuery withAccount(String account) {
+        this.account = account;
+        return this;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public RdsQuery withAccountId(String accountId) {
+        this.accountId = accountId;
+        return this;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public RdsQuery withRegion(String region) {
+        this.region = region;
+        return this;
+    }
+
+    public String getSdlc() {
+        return sdlc;
+    }
+
+    public RdsQuery withSdlc(String sdlc) {
+        this.sdlc = sdlc;
+        return this;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public RdsQuery withAddress(String address) {
+        this.address = address;
+        return this;
+    }
+
+    public String getDbName() {
+        return dbName;
+    }
+
+    public RdsQuery withDbName(String dbName) {
+        this.dbName = dbName;
+        return this;
+    }
+
+    public RdsQuery(String account, String accountId, String region, String sdlc, String address, String dbName) {
+        this.account = account;
+        this.accountId = accountId;
+        this.region = region;
+        this.sdlc = sdlc;
+        this.address = address;
+        this.dbName = dbName;
+    }
+
+    public RdsQuery() {
+    }
+}

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsQuery.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsQuery.java
@@ -18,6 +18,7 @@
 package org.finra.gatekeeper.rds.model;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 
 public class RdsQuery {
     /**
@@ -99,7 +100,7 @@ public class RdsQuery {
         return dbInstanceName;
     }
 
-    public RdsQuery withDbName(String dbName) {
+    public RdsQuery withDbInstanceName(String dbName) {
         this.dbInstanceName = dbName;
         return this;
     }
@@ -126,5 +127,23 @@ public class RdsQuery {
                 .add("address", address)
                 .add("dbInstanceName", dbInstanceName)
                 .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RdsQuery)) return false;
+        RdsQuery rdsQuery = (RdsQuery) o;
+        return Objects.equal(account, rdsQuery.account) &&
+                Objects.equal(accountId, rdsQuery.accountId) &&
+                Objects.equal(region, rdsQuery.region) &&
+                Objects.equal(sdlc, rdsQuery.sdlc) &&
+                Objects.equal(address, rdsQuery.address) &&
+                Objects.equal(dbInstanceName, rdsQuery.dbInstanceName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(account, accountId, region, sdlc, address, dbInstanceName);
     }
 }

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsRevokeAccessQuery.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsRevokeAccessQuery.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.finra.gatekeeper.rds.model;
+
+public class RdsRevokeAccessQuery extends RdsQuery {
+    /**
+     * The user to create
+     */
+    private String user;
+
+    /**
+     * The role to give the user
+     */
+    private RoleType role;
+
+    public String getUser() {
+        return user;
+    }
+
+    public RdsRevokeAccessQuery withUser(String user) {
+        this.user = user;
+        return this;
+    }
+
+    public RoleType getRole() {
+        return role;
+    }
+
+    public RdsRevokeAccessQuery withRole(RoleType role) {
+        this.role = role;
+        return this;
+    }
+
+    public RdsRevokeAccessQuery(String account, String accountId, String region, String sdlc, String address, String dbName, String user, RoleType role) {
+        super(account, accountId, region, sdlc, address, dbName);
+        this.user = user;
+        this.role = role;
+    }
+
+    public RdsRevokeAccessQuery(String account, String accountId, String region, String sdlc, String address, String dbName) {
+        super(account, accountId, region, sdlc, address, dbName);
+    }
+}

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsRevokeAccessQuery.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsRevokeAccessQuery.java
@@ -17,6 +17,8 @@
 
 package org.finra.gatekeeper.rds.model;
 
+import com.google.common.base.MoreObjects;
+
 public class RdsRevokeAccessQuery extends RdsQuery {
     /**
      * The user to create
@@ -46,13 +48,21 @@ public class RdsRevokeAccessQuery extends RdsQuery {
         return this;
     }
 
-    public RdsRevokeAccessQuery(String account, String accountId, String region, String sdlc, String address, String dbName, String user, RoleType role) {
-        super(account, accountId, region, sdlc, address, dbName);
+    public RdsRevokeAccessQuery(String account, String accountId, String region, String sdlc, String address, String dbInstanceName, String user, RoleType role) {
+        super(account, accountId, region, sdlc, address, dbInstanceName);
         this.user = user;
         this.role = role;
     }
 
-    public RdsRevokeAccessQuery(String account, String accountId, String region, String sdlc, String address, String dbName) {
-        super(account, accountId, region, sdlc, address, dbName);
+    public RdsRevokeAccessQuery(String account, String accountId, String region, String sdlc, String address, String dbInstanceName) {
+        super(account, accountId, region, sdlc, address, dbInstanceName);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("user", user)
+                .add("role", role)
+                .toString();
     }
 }

--- a/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsRevokeAccessQuery.java
+++ b/services/db/src/main/java/org/finra/gatekeeper/rds/model/RdsRevokeAccessQuery.java
@@ -18,6 +18,7 @@
 package org.finra.gatekeeper.rds.model;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 
 public class RdsRevokeAccessQuery extends RdsQuery {
     /**
@@ -64,5 +65,20 @@ public class RdsRevokeAccessQuery extends RdsQuery {
                 .add("user", user)
                 .add("role", role)
                 .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RdsRevokeAccessQuery)) return false;
+        if (!super.equals(o)) return false;
+        RdsRevokeAccessQuery that = (RdsRevokeAccessQuery) o;
+        return Objects.equal(user, that.user) &&
+                role == that.role;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(super.hashCode(), user, role);
     }
 }

--- a/services/rds/src/main/java/org/finra/gatekeeper/configuration/AppConfig.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/configuration/AppConfig.java
@@ -19,8 +19,15 @@ package org.finra.gatekeeper.configuration;
 
 import freemarker.template.Configuration;
 import freemarker.template.TemplateExceptionHandler;
+import org.finra.gatekeeper.rds.interfaces.GKUserCredentialsProvider;
+import org.finra.gatekeeper.services.db.EnvVarDBCredentialsService;
 import org.finra.gatekeeper.services.email.EmailService;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
@@ -31,7 +38,10 @@ import java.util.Locale;
  * or any other AWS clients such as S3, SQS, etc.
  */
 @Component
-public class AppConfig {
+public class AppConfig implements ApplicationContextAware {
+    private final Logger logger = LoggerFactory.getLogger(AppConfig.class);
+    private ApplicationContext context;
+
     @Bean
     public freemarker.template.Configuration freemarkerConfig() {
         Configuration configuration = new freemarker.template.Configuration(freemarker.template.Configuration.VERSION_2_3_29);
@@ -41,5 +51,23 @@ public class AppConfig {
         configuration.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
 
         return configuration;
+    }
+
+    @Bean
+    public GKUserCredentialsProvider credentialsProviderConfig(GatekeeperProperties gatekeeperProperties){
+        logger.info("************** CREDENTIALS PROVIDER SETUP **************");
+        String credentialProvider = gatekeeperProperties.getDb().getDbCredentialProvider();
+        if(credentialProvider == null){
+            logger.info("No credentials provider was provided, using default environmental credentials provider.");
+            return new EnvVarDBCredentialsService(gatekeeperProperties);
+        }
+        logger.info("Using provided credential provider: " + credentialProvider);
+        return (GKUserCredentialsProvider) context.getBean(credentialProvider);
+
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.context = applicationContext;
     }
 }

--- a/services/rds/src/main/java/org/finra/gatekeeper/configuration/AppConfig.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/configuration/AppConfig.java
@@ -53,10 +53,10 @@ public class AppConfig implements ApplicationContextAware {
         return configuration;
     }
 
-    @Bean
+    @Bean(name="credentialsProvider")
     public GKUserCredentialsProvider credentialsProviderConfig(GatekeeperProperties gatekeeperProperties){
         logger.info("************** CREDENTIALS PROVIDER SETUP **************");
-        String credentialProvider = gatekeeperProperties.getDb().getDbCredentialProvider();
+        String credentialProvider = gatekeeperProperties.getDb().getGkCredentialProvider();
         if(credentialProvider == null){
             logger.info("No credentials provider was provided, using default environmental credentials provider.");
             return new EnvVarDBCredentialsService(gatekeeperProperties);

--- a/services/rds/src/main/java/org/finra/gatekeeper/configuration/GatekeeperProperties.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/configuration/GatekeeperProperties.java
@@ -362,7 +362,7 @@ public class GatekeeperProperties {
 
     public static class GatekeeperDbProperties{
         private String gkUser;
-        private String dbCredentialProvider;
+        private String gkCredentialProvider;
         private String gkPass;
         private String assumeMinServerVersion;
         private String ssl;
@@ -489,12 +489,12 @@ public class GatekeeperProperties {
             return this;
         }
 
-        public String getDbCredentialProvider() {
-            return dbCredentialProvider;
+        public String getGkCredentialProvider() {
+            return gkCredentialProvider;
         }
 
-        public GatekeeperDbProperties setDbCredentialProvider(String dbCredentialProvider) {
-            this.dbCredentialProvider = dbCredentialProvider;
+        public GatekeeperDbProperties setGkCredentialProvider(String gkCredentialProvider) {
+            this.gkCredentialProvider = gkCredentialProvider;
             return this;
         }
     }

--- a/services/rds/src/main/java/org/finra/gatekeeper/configuration/GatekeeperProperties.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/configuration/GatekeeperProperties.java
@@ -362,6 +362,7 @@ public class GatekeeperProperties {
 
     public static class GatekeeperDbProperties{
         private String gkUser;
+        private String dbCredentialProvider;
         private String gkPass;
         private String assumeMinServerVersion;
         private String ssl;
@@ -485,6 +486,15 @@ public class GatekeeperProperties {
 
         public GatekeeperDbProperties setMysql(MySqlDbProperties mysql) {
             this.mysql = mysql;
+            return this;
+        }
+
+        public String getDbCredentialProvider() {
+            return dbCredentialProvider;
+        }
+
+        public GatekeeperDbProperties setDbCredentialProvider(String dbCredentialProvider) {
+            this.dbCredentialProvider = dbCredentialProvider;
             return this;
         }
     }

--- a/services/rds/src/main/java/org/finra/gatekeeper/controllers/LookupController.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/controllers/LookupController.java
@@ -52,23 +52,30 @@ class LookupController {
     }
 
     @RequestMapping(value = "/searchDBInstances", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<GatekeeperRDSInstance> searchRDSInstances(@RequestParam("account") String account, @RequestParam("region") String region,
-                                                          @RequestParam("searchText") String searchString, @RequestParam("type") String type){
-        return rdsLookupService.getInstances(new AWSEnvironment(account.toUpperCase(), region), type, searchString.toLowerCase());
+    public List<GatekeeperRDSInstance> searchRDSInstances(@RequestParam("account") String account,
+                                                          @RequestParam("region") String region,
+                                                          @RequestParam("sdlc") String sdlc,
+                                                          @RequestParam("searchText") String searchString,
+                                                          @RequestParam("type") String type){
+        return rdsLookupService.getInstances(new AWSEnvironment(account.toUpperCase(), region, sdlc), type, searchString.toLowerCase());
     }
 
     @RequestMapping(value = "/getAvailableSchemas", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public Map<RoleType, List<String>> getAvailableSchemas(@RequestParam("account") String account, @RequestParam("region") String region,
-                                                           @RequestParam("instanceId") String instanceId, @RequestParam("instanceName") String instanceName) throws Exception{
-        return rdsLookupService.getSchemasForInstance(new AWSEnvironment(account.toUpperCase(), region), instanceId, instanceName);
+    public Map<RoleType, List<String>> getAvailableSchemas(@RequestParam("account") String account,
+                                                           @RequestParam("region") String region,
+                                                           @RequestParam("sdlc") String sdlc,
+                                                           @RequestParam("instanceId") String instanceId,
+                                                           @RequestParam("instanceName") String instanceName) throws Exception{
+        return rdsLookupService.getSchemasForInstance(new AWSEnvironment(account.toUpperCase(), region, sdlc), instanceId, instanceName);
     }
 
     @RequestMapping(value="/getUsers", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public List<DbUser> getUsersForInstance(@RequestParam("account") String account,
                                             @RequestParam("region") String region,
+                                            @RequestParam("sdlc") String sdlc,
                                             @RequestParam("instanceId") String instanceId,
                                             @RequestParam("instanceName") String instanceName) throws Exception{
-        return rdsLookupService.getUsersForInstance(new AWSEnvironment(account.toUpperCase(), region), instanceId, instanceName);
+        return rdsLookupService.getUsersForInstance(new AWSEnvironment(account.toUpperCase(), region, sdlc), instanceId, instanceName);
 
     }
 }

--- a/services/rds/src/main/java/org/finra/gatekeeper/controllers/wrappers/RemoveUsersWrapper.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/controllers/wrappers/RemoveUsersWrapper.java
@@ -25,6 +25,7 @@ public class RemoveUsersWrapper {
 
     private String account;
     private String region;
+    private String sdlc;
     private String instanceId;
     private String instanceName;
     private List<DbUser> users;
@@ -72,6 +73,15 @@ public class RemoveUsersWrapper {
 
     public RemoveUsersWrapper setUsers(List<DbUser> users) {
         this.users = users;
+        return this;
+    }
+
+    public String getSdlc() {
+        return sdlc;
+    }
+
+    public RemoveUsersWrapper setSdlc(String sdlc) {
+        this.sdlc = sdlc;
         return this;
     }
 

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/AccessRequestService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/AccessRequestService.java
@@ -31,13 +31,13 @@ import org.finra.gatekeeper.controllers.wrappers.AccessRequestWrapper;
 import org.finra.gatekeeper.controllers.wrappers.ActiveAccessRequestWrapper;
 import org.finra.gatekeeper.controllers.wrappers.CompletedAccessRequestWrapper;
 import org.finra.gatekeeper.exception.GatekeeperException;
+import org.finra.gatekeeper.rds.interfaces.GKUserCredentialsProvider;
 import org.finra.gatekeeper.rds.model.RoleType;
 import org.finra.gatekeeper.services.accessrequest.model.*;
 import org.finra.gatekeeper.services.accessrequest.model.response.AccessRequestCreationOutcome;
 import org.finra.gatekeeper.services.accessrequest.model.response.AccessRequestCreationResponse;
 import org.finra.gatekeeper.services.auth.model.AppApprovalThreshold;
 import org.finra.gatekeeper.services.auth.model.RoleMembership;
-import org.finra.gatekeeper.services.aws.model.AWSEnvironment;
 import org.finra.gatekeeper.services.db.DatabaseConnectionService;
 import org.finra.gatekeeper.services.auth.GatekeeperRoleService;
 import org.finra.gatekeeper.services.auth.GatekeeperRdsRole;
@@ -70,6 +70,7 @@ public class AccessRequestService {
     private final AccountInformationService accountInformationService;
     private final GatekeeperOverrideProperties overridePolicy;
     private final DatabaseConnectionService databaseConnectionService;
+    private final GKUserCredentialsProvider gkUserCredentialsProvider;
     private final String REJECTED = "REJECTED";
     private final String APPROVED = "APPROVED";
     private final String CANCELED = "CANCELED";
@@ -83,7 +84,8 @@ public class AccessRequestService {
                                 GatekeeperApprovalProperties gatekeeperApprovalProperties,
                                 AccountInformationService accountInformationService,
                                 GatekeeperOverrideProperties overridePolicy,
-                                DatabaseConnectionService databaseConnectionService){
+                                DatabaseConnectionService databaseConnectionService,
+                                GKUserCredentialsProvider gkUserCredentialsProvider){
         this.taskService = taskService;
         this.accessRequestRepository = accessRequestRepository;
         this.gatekeeperRoleService = gatekeeperRoleService;
@@ -93,6 +95,7 @@ public class AccessRequestService {
         this.accountInformationService = accountInformationService;
         this.overridePolicy = overridePolicy;
         this.databaseConnectionService = databaseConnectionService;
+        this.gkUserCredentialsProvider = gkUserCredentialsProvider;
     }
 
     /**
@@ -118,8 +121,6 @@ public class AccessRequestService {
         request.getUsers().forEach(u -> u.setUserId("gk_" + u.getUserId()));
         Account theAccount = accountInformationService.getAccountByAlias(request.getAccount());
 
-        AWSEnvironment environment = new AWSEnvironment(theAccount.getAlias().toUpperCase(), request.getRegion());
-
         AccessRequest accessRequest = new AccessRequest()
                 .setAccount(request.getAccount().toUpperCase())
                 .setAccountSdlc(request.getAccountSdlc())
@@ -136,11 +137,13 @@ public class AccessRequestService {
 
         logger.info("Checking Users associated with this access request");
 
-        Map<String, List<String>> checkResult;
+        List<String> checkResult;
+        AWSRdsDatabase database = accessRequest.getAwsRdsInstances().get(0);
         try {
-            checkResult = databaseConnectionService.checkUsersAndDbs(request.getRoles(), request.getUsers(), request.getInstances());
+            checkResult = databaseConnectionService.checkUsersAndDbs(request.getRoles(), request.getUsers(), request.getInstances().get(0),
+                    gkUserCredentialsProvider.getGatekeeperSecret(accessRequest.getAccount(), accessRequest.getRegion(), accessRequest.getAccountSdlc(), database.getName()));
         }catch(Exception e){
-            throw new GatekeeperException("Unable to verify the Users for the provided databases");
+            throw new GatekeeperException("Unable to verify the Users for the provided databases", e);
         }
 
         if(!checkResult.isEmpty()){

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/AWSEnvironment.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/AWSEnvironment.java
@@ -28,9 +28,10 @@ public class AWSEnvironment {
     private String region;
     private String sdlc;
 
-    public AWSEnvironment(String account, String region){
+    public AWSEnvironment(String account, String region, String sdlc){
         this.account = account;
         this.region = region;
+        this.sdlc = sdlc;
     }
 
     public String getAccount(){

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/AWSEnvironment.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/AWSEnvironment.java
@@ -18,8 +18,7 @@
 package org.finra.gatekeeper.services.aws.model;
 
 import com.google.common.base.MoreObjects;
-
-import java.util.Objects;
+import com.google.common.base.Objects;
 
 /**
  * Simple POJO used to manage cache.
@@ -27,6 +26,7 @@ import java.util.Objects;
 public class AWSEnvironment {
     private String account;
     private String region;
+    private String sdlc;
 
     public AWSEnvironment(String account, String region){
         this.account = account;
@@ -41,24 +41,23 @@ public class AWSEnvironment {
         return region;
     }
 
-    @Override
-    public boolean equals(Object o){
-        if(this == o){
-            return true;
-        }
-
-        if (o == null || !getClass().equals(o.getClass())) {
-            return false;
-        }
-
-        AWSEnvironment that = (AWSEnvironment)o;
-        return Objects.equals(this.account, that.getAccount()) && Objects.equals(this.region, that.getRegion());
+    public String getSdlc() {
+        return sdlc;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AWSEnvironment that = (AWSEnvironment) o;
+        return Objects.equal(account, that.account) &&
+                Objects.equal(region, that.region) &&
+                Objects.equal(sdlc, that.sdlc);
+    }
 
     @Override
     public int hashCode() {
-        return Objects.hash(account, region);
+        return Objects.hashCode(account, region, sdlc);
     }
 
     @Override
@@ -66,6 +65,7 @@ public class AWSEnvironment {
         return MoreObjects.toStringHelper(this)
                 .add("account", account)
                 .add("region", region)
+                .add("sdlc", sdlc)
                 .toString();
     }
 }

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/db/DatabaseConnectionService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/db/DatabaseConnectionService.java
@@ -65,7 +65,7 @@ public class DatabaseConnectionService {
         try{
             status = databaseConnectionFactory.getConnection(db.getEngine()).grantAccess(
                     new RdsGrantAccessQuery(account.getAlias(), account.getAccountId(), awsEnvironment.getRegion(), account.getSdlc(),
-                            getAddress(db.getEndpoint(), db.getDbName()), db.getDbName())
+                            getAddress(db.getEndpoint(), db.getDbName()), db.getName())
                     .withUser(user)
                     .withPassword(password)
                     .withRole(roleType)
@@ -89,7 +89,7 @@ public class DatabaseConnectionService {
         try{
             status = databaseConnectionFactory.getConnection(db.getEngine())
                     .revokeAccess(new RdsRevokeAccessQuery(account.getAlias(), account.getAccountId(), awsEnvironment.getRegion(), awsEnvironment.getSdlc(),
-                            getAddress(db.getEndpoint(), db.getDbName()), db.getDbName())
+                            getAddress(db.getEndpoint(), db.getDbName()), db.getName())
                             .withUser(user)
                             .withRole(roleType));
             logger.info("User " + user + " removed from " + db.getName() + "(" + db.getInstanceId() + ")? " + status);
@@ -241,7 +241,8 @@ public class DatabaseConnectionService {
             outcome = databaseConnectionFactory.getConnection(db.getEngine())
                     .checkIfUsersHasTables(
                             new RdsCheckUsersTableQuery(account.getAlias(), account.getAccountId(), awsEnvironment.getRegion(), awsEnvironment.getSdlc(),
-                                    getAddress(db.getEndpoint(), db.getDbName()), db.getName()));
+                                    getAddress(db.getEndpoint(), db.getDbName()), db.getName())
+                                        .withUsers(userWithRoles));
         }catch(Exception ex){
             logger.error("Failed to check users on database: ", ex);
         }

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/db/EnvVarDBCredentialsService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/db/EnvVarDBCredentialsService.java
@@ -16,12 +16,17 @@
  */
 package org.finra.gatekeeper.services.db;
 
+import com.google.common.base.MoreObjects;
 import org.finra.gatekeeper.configuration.GatekeeperProperties;
 import org.finra.gatekeeper.rds.interfaces.GKUserCredentialsProvider;
+import org.finra.gatekeeper.rds.model.RdsQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class EnvVarDBCredentialsService implements GKUserCredentialsProvider {
 
+    private final Logger logger = LoggerFactory.getLogger(EnvVarDBCredentialsService.class);
     private String secret;
 
     @Autowired
@@ -30,7 +35,13 @@ public class EnvVarDBCredentialsService implements GKUserCredentialsProvider {
     }
 
     @Override
-    public String getGatekeeperSecret(String account, String region, String sdlc, String instanceName) {
+    public String getGatekeeperSecret(RdsQuery rdsQuery) {
+        logger.info("Getting Environment Variable based secret" );
+        logger.info(MoreObjects.toStringHelper(this)
+                .add("account", rdsQuery.getAccount())
+                .add("region", rdsQuery.getRegion())
+                .add("sdlc", rdsQuery.getSdlc())
+                .add("database", rdsQuery.getDbName()).toString());
         return secret;
     }
 }

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/db/EnvVarDBCredentialsService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/db/EnvVarDBCredentialsService.java
@@ -41,7 +41,7 @@ public class EnvVarDBCredentialsService implements GKUserCredentialsProvider {
                 .add("account", rdsQuery.getAccount())
                 .add("region", rdsQuery.getRegion())
                 .add("sdlc", rdsQuery.getSdlc())
-                .add("database", rdsQuery.getDbName()).toString());
+                .add("database", rdsQuery.getDbInstanceName()).toString());
         return secret;
     }
 }

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/db/EnvVarDBCredentialsService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/db/EnvVarDBCredentialsService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.finra.gatekeeper.services.db;
+
+import org.finra.gatekeeper.configuration.GatekeeperProperties;
+import org.finra.gatekeeper.rds.interfaces.GKUserCredentialsProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class EnvVarDBCredentialsService implements GKUserCredentialsProvider {
+
+    private String secret;
+
+    @Autowired
+    public EnvVarDBCredentialsService(GatekeeperProperties gatekeeperProperties){
+        this.secret = gatekeeperProperties.getDb().getGkPass();
+    }
+
+    @Override
+    public String getGatekeeperSecret(String account, String region, String sdlc, String instanceName) {
+        return secret;
+    }
+}

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/db/connections/MySQLDBConnection.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/db/connections/MySQLDBConnection.java
@@ -201,7 +201,7 @@ public class MySQLDBConnection implements DBConnection {
         String userRole = getGkUserName(user, role); //16 is the maximum length for a user in MySQL, if there's a user hitting this limit, a shorter suffix shall be used
         //revoke the user if they exist
         revokeAccess(new RdsRevokeAccessQuery(rdsGrantAccessQuery.getAccount(), rdsGrantAccessQuery.getAccountId(), rdsGrantAccessQuery.getRegion(), rdsGrantAccessQuery.getSdlc(),
-                rdsGrantAccessQuery.getAddress(), rdsGrantAccessQuery.getDbName())
+                rdsGrantAccessQuery.getAddress(), rdsGrantAccessQuery.getDbInstanceName())
                     .withUser(user)
                     .withRole(role));
 

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/db/connections/PostgresDBConnection.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/db/connections/PostgresDBConnection.java
@@ -215,7 +215,7 @@ public class PostgresDBConnection implements DBConnection {
      * Check to see if this user is the owner of any tables on the DB
      *
      * @param rdsCheckUsersTableQuery - the query details for the db
-     * @return boolean - true if the user still owns tables, false otherwise (they don't exist)
+     * @return List of String - List of users that still own tables
      *
      * @throws SQLException - if there's an issue executing the query on the database
      */

--- a/services/rds/src/main/resources/application.yml
+++ b/services/rds/src/main/resources/application.yml
@@ -200,4 +200,5 @@ gatekeeper:
       ssl: connectTimeout=${gatekeeper.rds.connectTimeout}&useSSL=${gatekeeper.rds.ssl}&requireSSL=${gatekeeper.rds.ssl}&serverSslCert=${gatekeeper.rds.sslCert}
     gkUser: ${gatekeeper.rds.user}
     gkPass: ${gatekeeper.rds.password}
+    gkCredentialProvider: ${gatekeeper.rds.gkCredentialProvider}
 

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/aws/RdsLookupServiceTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/aws/RdsLookupServiceTest.java
@@ -81,7 +81,7 @@ public class RdsLookupServiceTest {
     public void setUp() throws Exception {
         gatekeeperProperties = new GatekeeperProperties()
                 .setAppIdentityTag(APP_IDENTITY);
-        rdsLookupService = new RdsLookupService(awsSessionService, databaseConnectionService, gkUserCredentialsProvider, sgLookupService, gatekeeperProperties);
+        rdsLookupService = new RdsLookupService(awsSessionService, databaseConnectionService, sgLookupService, gatekeeperProperties);
         test = new AWSEnvironment("test", "test", "test");
 
         Mockito.when(awsSessionService.getRDSSession(test)).thenReturn(amazonRDSClient);

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/aws/RdsLookupServiceTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/aws/RdsLookupServiceTest.java
@@ -22,13 +22,13 @@ import com.amazonaws.services.rds.model.*;
 import org.finra.gatekeeper.configuration.GatekeeperProperties;
 import org.finra.gatekeeper.rds.exception.GKUnsupportedDBException;
 import org.finra.gatekeeper.rds.interfaces.GKUserCredentialsProvider;
+import org.finra.gatekeeper.services.accessrequest.model.AWSRdsDatabase;
 import org.finra.gatekeeper.services.aws.model.AWSEnvironment;
 import org.finra.gatekeeper.services.aws.model.GatekeeperRDSInstance;
 import org.finra.gatekeeper.services.db.DatabaseConnectionService;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -67,13 +67,22 @@ public class RdsLookupServiceTest {
     private final String DB_NAME = "postgres";
     private final Integer DB_PORT = 5432;
     private final List<String> roles = Arrays.asList("gk_readonly", "gk_datafix", "gk_dba");
+    private final AWSRdsDatabase postgres = new AWSRdsDatabase()
+            .setEngine(RDS_ENGINE_PG);
+
+    private final AWSRdsDatabase oracle = new AWSRdsDatabase()
+            .setEngine(RDS_ENGINE_ORACLE);
+
+    private DBInstance dbA, dbB, dbC, dbD, dbE, dbF, dbG, dbH, dbI;
+    private DBCluster clusterA, clusterB, clusterC, clusterD, clusterE, clusterF, clusterG, clusterH, clusterI, clusterJ;
+
 
     @Before
     public void setUp() throws Exception {
         gatekeeperProperties = new GatekeeperProperties()
                 .setAppIdentityTag(APP_IDENTITY);
         rdsLookupService = new RdsLookupService(awsSessionService, databaseConnectionService, gkUserCredentialsProvider, sgLookupService, gatekeeperProperties);
-        test = new AWSEnvironment("test", "test");
+        test = new AWSEnvironment("test", "test", "test");
 
         Mockito.when(awsSessionService.getRDSSession(test)).thenReturn(amazonRDSClient);
 
@@ -84,29 +93,37 @@ public class RdsLookupServiceTest {
                         new OptionGroup()
                                 .withOptionGroupName("test-og")
                                 .withOptions(new Option().withOptionName("SSL").withPort(1234))));
-        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(RDS_ENGINE_PG), Mockito.contains("instance"), Mockito.any())).thenReturn("");
-        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(RDS_ENGINE_ORACLE), Mockito.contains("instance"), Mockito.any())).thenReturn("");
-        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(RDS_ENGINE_PG), Mockito.contains("instance"), Mockito.any())).thenReturn(roles);
-        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(RDS_ENGINE_ORACLE), Mockito.contains("instance"), Mockito.any())).thenReturn(roles);
-        Mockito.when(databaseConnectionService.checkDb(Mockito.eq("sqlserver"), Mockito.contains("unsupported"), Mockito.any())).thenThrow(new GKUnsupportedDBException("Unsupported DB"));
-        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(RDS_ENGINE_PG), Mockito.contains("missing"), Mockito.any())).thenReturn("gatekeeper user missing createrole");
-        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(RDS_ENGINE_PG), Mockito.contains("rolesfailunable"), Mockito.any())).thenReturn("");
-        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(RDS_ENGINE_PG), Mockito.contains("rolesfailpassword"), Mockito.any())).thenReturn("");
-        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(RDS_ENGINE_PG), Mockito.contains("rolesfailunable"), Mockito.any())).thenThrow(new Exception("Unable to get roles"));
-        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(RDS_ENGINE_PG), Mockito.contains("rolesfailpassword"), Mockito.any())).thenThrow(new Exception("Unable to login: password authentication failed"));
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(dbA), Mockito.any())).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(dbB), Mockito.any())).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(dbC), Mockito.any())).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(dbD), Mockito.any())).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(dbE), Mockito.any())).thenThrow(GKUnsupportedDBException.class);
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(dbF), Mockito.any())).thenReturn("Gatekeeper user missing createrole");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(dbG), Mockito.any())).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(dbH), Mockito.any())).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(dbI), Mockito.any())).thenReturn("");
+        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(dbA), Mockito.any())).thenReturn(roles);
+        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(dbI), Mockito.any())).thenReturn(roles);
+        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(dbG), Mockito.any())).thenThrow(new Exception("Unable to get roles"));
+        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(dbH), Mockito.any())).thenThrow(new Exception("Unable to login: password authentication failed"));
 
         //AURORA
         Mockito.when(amazonRDSClient.describeDBClusters(Mockito.any())).thenReturn(initializeClusters());
         Mockito.when(amazonRDSClient.listTagsForResource(Mockito.any())).thenReturn(initializeTags());
         Mockito.when(sgLookupService.fetchSgsForAccountRegion(test)).thenReturn(Arrays.asList(SG_ONE, SG_TWO));
-        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("dbendpoint"), Mockito.any())).thenReturn("");
-        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("rolesfailunable"), Mockito.any())).thenReturn("");
-        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("rolesfailpassword"), Mockito.any())).thenReturn("");
-        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("unsupported"), Mockito.any())).thenThrow(new GKUnsupportedDBException("Unsupported DB"));
-        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("missing"), Mockito.any())).thenReturn("gatekeeper user missing createrole");
-        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("dbendpoint"), Mockito.any())).thenReturn(roles);
-        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("rolesfailunable"), Mockito.any())).thenThrow(new Exception("Unable to get roles"));
-        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(AURORA_ENGINE), Mockito.contains("rolesfailpassword"), Mockito.any())).thenThrow(new Exception("Unable to login: password authentication failed"));
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(clusterA), Mockito.any())).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(clusterB), Mockito.any())).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(clusterC), Mockito.any())).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(clusterD), Mockito.any())).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(clusterE), Mockito.any())).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(clusterF), Mockito.any())).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(clusterG), Mockito.any())).thenThrow(GKUnsupportedDBException.class);
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(clusterH), Mockito.any())).thenReturn("Gatekeeper user missing createrole");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(clusterI), Mockito.any())).thenReturn("");
+        Mockito.when(databaseConnectionService.checkDb(Mockito.eq(clusterJ), Mockito.any())).thenReturn("");
+        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(clusterA), Mockito.any())).thenReturn(roles);
+        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(clusterI), Mockito.any())).thenThrow(new Exception("Unable to get roles"));
+        Mockito.when(databaseConnectionService.getAvailableRolesForDb(Mockito.eq(clusterJ), Mockito.any())).thenThrow(new Exception("Unable to login: password authentication failed"));
     }
 
     @Test(expected=IllegalArgumentException.class)
@@ -182,7 +199,7 @@ public class RdsLookupServiceTest {
         instances = rdsLookupService.getInstances(test, "RDS", "gk-F");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
-        Assert.assertEquals("gatekeeper user missing createrole", instance.getStatus());
+        Assert.assertEquals("Gatekeeper user missing createrole", instance.getStatus());
         Assert.assertFalse(instance.getEnabled());
     }
 
@@ -322,7 +339,7 @@ public class RdsLookupServiceTest {
         instances = rdsLookupService.getInstances(test, "AURORA", "gk-H");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
-        Assert.assertEquals("gatekeeper user missing createrole", instance.getStatus());
+        Assert.assertEquals("Gatekeeper user missing createrole", instance.getStatus());
         Assert.assertFalse(instance.getEnabled());
     }
 
@@ -375,30 +392,30 @@ public class RdsLookupServiceTest {
 
     private DescribeDBInstancesResult initializeInstances(){
         return new DescribeDBInstancesResult().withDBInstances(Arrays.asList(
-                initializeInstance("instance1", RDS_ENGINE_PG, "gk-A-instance", "db-gk1", STATUS_AVAILABLE, SG_ONE, null),
-                initializeInstance("instance2", AURORA_ENGINE, "gk-B-instance", "db-gk2", STATUS_AVAILABLE, SG_ONE, null),
-                initializeInstance("instance3", RDS_ENGINE_PG, "gk-C-instance", "db-gk3", STATUS_AVAILABLE, "gk-unsupport", null),
-                initializeInstance("instance4", RDS_ENGINE_PG, "gk-D-instance", "db-gk4", STATUS_AVAILABLE, SG_ONE, "replica1"),
-                initializeInstance("unsupported", "sqlserver", "gk-E-instance", "db-gk5", STATUS_AVAILABLE, SG_TWO, null),
-                initializeInstance("missing", RDS_ENGINE_PG, "gk-F-instance", "db-gk6", STATUS_AVAILABLE, SG_TWO, null),
-                initializeInstance("rolesfailunable", RDS_ENGINE_PG, "gk-G-instance", "db-gk7", STATUS_AVAILABLE, SG_TWO, null),
-                initializeInstance("rolesfailpassword", RDS_ENGINE_PG, "gk-H-instance", "db-gk8", STATUS_AVAILABLE, SG_TWO, null),
-                initializeInstance("instance5", RDS_ENGINE_ORACLE, "gk-I-instance", "db-gk9", STATUS_AVAILABLE, SG_TWO, null)
+                (dbA = initializeInstance("instance1", RDS_ENGINE_PG, "gk-A-instance", "db-gk1", STATUS_AVAILABLE, SG_ONE, null)),
+                (dbB = initializeInstance("instance2", AURORA_ENGINE, "gk-B-instance", "db-gk2", STATUS_AVAILABLE, SG_ONE, null)),
+                (dbC = initializeInstance("instance3", RDS_ENGINE_PG, "gk-C-instance", "db-gk3", STATUS_AVAILABLE, "gk-unsupport", null)),
+                (dbD = initializeInstance("instance4", RDS_ENGINE_PG, "gk-D-instance", "db-gk4", STATUS_AVAILABLE, SG_ONE, "replica1")),
+                (dbE = initializeInstance("unsupported", "sqlserver", "gk-E-instance", "db-gk5", STATUS_AVAILABLE, SG_TWO, null)),
+                (dbF = initializeInstance("missing", RDS_ENGINE_PG, "gk-F-instance", "db-gk6", STATUS_AVAILABLE, SG_TWO, null)),
+                (dbG = initializeInstance("rolesfailunable", RDS_ENGINE_PG, "gk-G-instance", "db-gk7", STATUS_AVAILABLE, SG_TWO, null)),
+                (dbH = initializeInstance("rolesfailpassword", RDS_ENGINE_PG, "gk-H-instance", "db-gk8", STATUS_AVAILABLE, SG_TWO, null)),
+                (dbI = initializeInstance("instance5", RDS_ENGINE_ORACLE, "gk-I-instance", "db-gk9", STATUS_AVAILABLE, SG_TWO, null))
         ));
     }
 
     private DescribeDBClustersResult initializeClusters(){
         return new DescribeDBClustersResult().withDBClusters(Arrays.asList(
-                initializeCluster("dbendpoint1", "gk-A-cluster", "cluster-gk1", STATUS_AVAILABLE, SG_ONE, null, 2, true),
-                initializeCluster("dbendpoint2", "gk-B-cluster", "cluster-gk2", STATUS_STOPPED, SG_ONE, null, 1, true),
-                initializeCluster("dbendpoint3", "gk-C-cluster", "cluster-gk3", STATUS_AVAILABLE, SG_TWO, "replica1", 1, true),
-                initializeCluster("dbendpoint4", "gk-D-cluster", "cluster-gk4", STATUS_AVAILABLE, "gk-unsupportedsg", null, 3, true),
-                initializeCluster("dbendpoint5", "gk-E-cluster", "cluster-gk5", STATUS_AVAILABLE, SG_TWO, null, 0, true),
-                initializeCluster("dbendpoint6", "gk-F-cluster", "cluster-gk6", STATUS_AVAILABLE, SG_ONE, null, 2, false),
-                initializeCluster("unsupported", "gk-G-cluster", "cluster-gk7", STATUS_AVAILABLE, SG_ONE, null, 2, true),
-                initializeCluster("missing", "gk-H-cluster", "cluster-gk8", STATUS_AVAILABLE, SG_ONE, null, 2, true),
-                initializeCluster("rolesfailunable", "gk-I-cluster", "cluster-gk9", STATUS_AVAILABLE, SG_ONE, null, 2, true),
-                initializeCluster("rolesfailpassword", "gk-J-cluster", "cluster-gk10", STATUS_AVAILABLE, SG_ONE, null, 2, true)
+                (clusterA = initializeCluster("dbendpoint1", "gk-A-cluster", "cluster-gk1", STATUS_AVAILABLE, SG_ONE, null, 2, true)),
+                (clusterB = initializeCluster("dbendpoint2", "gk-B-cluster", "cluster-gk2", STATUS_STOPPED, SG_ONE, null, 1, true)),
+                (clusterC = initializeCluster("dbendpoint3", "gk-C-cluster", "cluster-gk3", STATUS_AVAILABLE, SG_TWO, "replica1", 1, true)),
+                (clusterD = initializeCluster("dbendpoint4", "gk-D-cluster", "cluster-gk4", STATUS_AVAILABLE, "gk-unsupportedsg", null, 3, true)),
+                (clusterE = initializeCluster("dbendpoint5", "gk-E-cluster", "cluster-gk5", STATUS_AVAILABLE, SG_TWO, null, 0, true)),
+                (clusterF = initializeCluster("dbendpoint6", "gk-F-cluster", "cluster-gk6", STATUS_AVAILABLE, SG_ONE, null, 2, false)),
+                (clusterG = initializeCluster("unsupported", "gk-G-cluster", "cluster-gk7", STATUS_AVAILABLE, SG_ONE, null, 2, true)),
+                (clusterH = initializeCluster("missing", "gk-H-cluster", "cluster-gk8", STATUS_AVAILABLE, SG_ONE, null, 2, true)),
+                (clusterI = initializeCluster("rolesfailunable", "gk-I-cluster", "cluster-gk9", STATUS_AVAILABLE, SG_ONE, null, 2, true)),
+                (clusterJ = initializeCluster("rolesfailpassword", "gk-J-cluster", "cluster-gk10", STATUS_AVAILABLE, SG_ONE, null, 2, true))
         ));
     }
 

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/db/DatabaseConnectionServiceTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/db/DatabaseConnectionServiceTest.java
@@ -1,3 +1,20 @@
+/*
+ *
+ * Copyright 2020. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.finra.gatekeeper.services.db;
 
 import com.amazonaws.services.rds.model.DBCluster;

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/db/DatabaseConnectionServiceTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/db/DatabaseConnectionServiceTest.java
@@ -1,0 +1,397 @@
+package org.finra.gatekeeper.services.db;
+
+import com.amazonaws.services.rds.model.DBCluster;
+import com.amazonaws.services.rds.model.DBInstance;
+import com.amazonaws.services.rds.model.Endpoint;
+import org.finra.gatekeeper.common.services.account.AccountInformationService;
+import org.finra.gatekeeper.common.services.account.model.Account;
+import org.finra.gatekeeper.exception.GatekeeperException;
+import org.finra.gatekeeper.rds.exception.GKUnsupportedDBException;
+import org.finra.gatekeeper.rds.model.*;
+import org.finra.gatekeeper.services.accessrequest.model.AWSRdsDatabase;
+import org.finra.gatekeeper.services.accessrequest.model.User;
+import org.finra.gatekeeper.services.accessrequest.model.UserRole;
+import org.finra.gatekeeper.services.aws.model.AWSEnvironment;
+import org.finra.gatekeeper.services.aws.model.GatekeeperRDSInstance;
+import org.finra.gatekeeper.services.db.factory.DatabaseConnectionFactory;
+import org.finra.gatekeeper.services.db.mockconnection.MockDBConnection;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class DatabaseConnectionServiceTest {
+
+    @Mock
+    private DatabaseConnectionFactory databaseConnectionFactory;
+
+    @Mock
+    private AccountInformationService accountInformationService;
+
+    @Spy
+    private MockDBConnection mockDBConnection;
+
+    RdsQuery expectedRequest;
+    RdsGrantAccessQuery expectedGrantRequest;
+    RdsRevokeAccessQuery expectedRevokeRequest;
+    RdsCheckUsersTableQuery expectedCheckUsersRequest;
+
+    private final String TEST_ENGINE = "testengine";
+    private final String TEST_UNSUPPORTED_ENGINE = "unsupportedEngine";
+    private AWSRdsDatabase database;
+    private AWSEnvironment environment;
+    private GatekeeperRDSInstance supportedGatekeeperRDSInstance;
+    private GatekeeperRDSInstance unsupportedGatekeeperRDSInstance;
+    private DBInstance rdsInstance;
+    private DBCluster auroraCluster;
+    private Account account;
+    private DbUser gkDbUser;
+    private DbUser gkDbUser2;
+    private DbUser nonGkDbUser;
+
+
+    private DatabaseConnectionService databaseConnectionService;
+
+    @Before
+    public void setUp() throws GKUnsupportedDBException {
+        database = new AWSRdsDatabase()
+                .setEngine(TEST_ENGINE)
+                .setApplication("TESTAPP")
+                .setDbName("testdb")
+                .setInstanceId("db-123456")
+                .setName("test-db-name")
+                .setEndpoint("test-db-name.1234567890.us-east-1.rds.amazonaws.com")
+                .setStatus("Available")
+                .setArn("testArn");
+
+        supportedGatekeeperRDSInstance = new GatekeeperRDSInstance(database.getInstanceId(), database.getName(), database.getDbName(), database.getEngine(), database.getStatus(), database.getArn(),
+                database.getEndpoint(), database.getApplication(), Arrays.asList("READONLY", "DBA", "DATAFIX"), true);
+        unsupportedGatekeeperRDSInstance = new GatekeeperRDSInstance(database.getInstanceId(), database.getName(), database.getDbName(), TEST_UNSUPPORTED_ENGINE, database.getStatus(), database.getArn(),
+                database.getEndpoint(), database.getApplication(), Arrays.asList("READONLY", "DBA", "DATAFIX"), true);
+        rdsInstance = new DBInstance()
+                .withDBInstanceIdentifier(database.getName())
+                .withEngine(database.getEngine())
+                .withDBName(database.getDbName())
+                .withDbiResourceId(database.getInstanceId())
+                .withEndpoint(new Endpoint().withAddress(database.getEndpoint()))
+                .withDBInstanceStatus(database.getStatus())
+                .withDBInstanceArn(database.getArn());
+
+        auroraCluster = new DBCluster()
+                .withDBClusterIdentifier(database.getName())
+                .withEngine(database.getEngine())
+                .withDatabaseName(database.getDbName())
+                .withDbClusterResourceId(database.getInstanceId())
+                .withEndpoint(database.getEndpoint())
+                .withStatus(database.getStatus())
+                .withDBClusterArn(database.getArn());
+
+        environment = new AWSEnvironment("test", "us-east-1", "DEV");
+
+        account = new Account()
+                .setName("Test Account")
+                .setSdlc("DEV")
+                .setAccountId("012345678901")
+                .setAlias("test")
+                .setGrouping(0);
+
+        gkDbUser = new DbUser()
+                .setUsername("gk_testhappy")
+                .setRoles(Collections.singletonList("READONLY"));
+
+        gkDbUser2 = new DbUser()
+                .setUsername("gk_testhappy2")
+                .setRoles(Collections.singletonList("READONLY"));
+
+        nonGkDbUser = new DbUser()
+                .setUsername("test")
+                .setRoles(Collections.emptyList());
+
+        String endpoint = database.getEndpoint() + "/" + database.getDbName();
+        expectedRequest = new RdsQuery()
+                .withAccount(account.getAlias())
+                .withAccountId(account.getAccountId())
+                .withRegion(environment.getRegion())
+                .withSdlc(environment.getSdlc())
+                .withAddress(endpoint)
+                .withDbInstanceName(database.getName());
+        expectedRevokeRequest = new RdsRevokeAccessQuery(account.getAlias(), account.getAccountId(), environment.getRegion(), environment.getSdlc(), endpoint, database.getName());
+        expectedGrantRequest = new RdsGrantAccessQuery(account.getAlias(), account.getAccountId(), environment.getRegion(), environment.getSdlc(), endpoint, database.getName());
+        expectedCheckUsersRequest = new RdsCheckUsersTableQuery(account.getAlias(), account.getAccountId(), environment.getRegion(), environment.getSdlc(), endpoint, database.getName());
+
+        Mockito.when(databaseConnectionFactory.getConnection(TEST_ENGINE)).thenReturn(mockDBConnection);
+        Mockito.when(databaseConnectionFactory.getConnection(TEST_UNSUPPORTED_ENGINE)).thenThrow(new GKUnsupportedDBException("UnsupportedDB"));
+        Mockito.when(accountInformationService.getAccountByAlias("test")).thenReturn(account);
+        databaseConnectionService = new DatabaseConnectionService(databaseConnectionFactory, accountInformationService);
+    }
+
+    /*
+     * Grant Access
+     */
+    @Test
+    public void testGrantAccessHappy() throws Exception {
+        ArgumentCaptor<RdsGrantAccessQuery> argumentCaptor = ArgumentCaptor.forClass(RdsGrantAccessQuery.class);
+        String testUser = "tstuserhappy";
+        String testPassword = "testpassword";
+        Integer timeDays = 1;
+        boolean outcome = databaseConnectionService.grantAccess(database, environment, testUser, RoleType.READONLY, testPassword, timeDays);
+        Mockito.verify(mockDBConnection).grantAccess(argumentCaptor.capture());
+        expectedGrantRequest.withUser(testUser)
+                .withPassword(testPassword)
+                .withRole(RoleType.READONLY)
+                .withTime(1);
+        RdsGrantAccessQuery actual = argumentCaptor.getValue();
+        Assert.assertEquals(expectedGrantRequest, actual);
+        Assert.assertTrue(outcome);
+    }
+
+    @Test
+    public void testGrantAccessUnsupported() throws Exception {
+        String testUser = "tstuser";
+        String testPassword = "testpassword";
+        Integer timeDays = 1;
+        database.setEngine(TEST_UNSUPPORTED_ENGINE);
+        boolean outcome = databaseConnectionService.grantAccess(database, environment, testUser, RoleType.READONLY, testPassword, timeDays);
+        Assert.assertFalse(outcome);
+    }
+
+    @Test
+    public void testGrantAccessError() throws Exception {
+        String testPassword = "testpassword";
+        Integer timeDays = 1;
+        boolean outcome = databaseConnectionService.grantAccess(database, environment, null, RoleType.READONLY, testPassword, timeDays);
+        Assert.assertFalse(outcome);
+    }
+
+    /*
+     * Revoke Access
+     */
+
+    @Test
+    public void testRevokeAccessHappy() throws Exception {
+        ArgumentCaptor<RdsRevokeAccessQuery> argumentCaptor = ArgumentCaptor.forClass(RdsRevokeAccessQuery.class);
+        String testUser = "tstuserhappy";
+        boolean outcome = databaseConnectionService.revokeAccess(database, environment, RoleType.READONLY, testUser);
+        Mockito.verify(mockDBConnection).revokeAccess(argumentCaptor.capture());
+        expectedRevokeRequest.withUser(testUser)
+                .withRole(RoleType.READONLY);
+        RdsRevokeAccessQuery actualRevokeRequest = argumentCaptor.getValue();
+        Assert.assertEquals(expectedRevokeRequest, actualRevokeRequest);
+        Assert.assertTrue(outcome);
+    }
+
+    @Test
+    public void testRevokeAccessUnsupportedDB() throws Exception {
+        String testUser = "tstuserhappy";
+        database.setEngine(TEST_UNSUPPORTED_ENGINE);
+        boolean outcome = databaseConnectionService.revokeAccess(database, environment, RoleType.READONLY, testUser);
+        expectedRevokeRequest.withUser(testUser)
+                .withRole(RoleType.READONLY);
+        Assert.assertFalse(outcome);
+    }
+
+    @Test
+    public void testRevokeAccessException() throws Exception {
+        String testUser = "tstuserhappy";
+        boolean outcome = databaseConnectionService.revokeAccess(database, environment, RoleType.READONLY, null);
+        expectedRevokeRequest.withUser(testUser)
+                .withRole(RoleType.READONLY);
+        Assert.assertFalse(outcome);
+    }
+
+    /*
+     * Force Revoke Access
+     */
+
+    @Test
+    public void testForceRevokeAccessHappySingle() throws Exception {
+        ArgumentCaptor<RdsRevokeAccessQuery> argumentCaptor = ArgumentCaptor.forClass(RdsRevokeAccessQuery.class);
+        List<DbUser> userList = Collections.singletonList(gkDbUser);
+        List<String> removedUsers = databaseConnectionService.forceRevokeAccessUsersOnDatabase(supportedGatekeeperRDSInstance, environment, userList);
+        Mockito.verify(mockDBConnection).revokeAccess(argumentCaptor.capture());
+        expectedRevokeRequest.withUser(gkDbUser.getUsername());
+        RdsRevokeAccessQuery actualRevokeRequest = argumentCaptor.getValue();
+        Assert.assertEquals(expectedRevokeRequest, actualRevokeRequest);
+        Assert.assertEquals(Collections.emptyList(), removedUsers);
+    }
+
+    @Test
+    public void testForceRevokeAccessHappyMulti() throws Exception {
+        ArgumentCaptor<RdsRevokeAccessQuery> argumentCaptor = ArgumentCaptor.forClass(RdsRevokeAccessQuery.class);
+        List<DbUser> userList = Arrays.asList(gkDbUser, gkDbUser2);
+        List<String> removedUsers = databaseConnectionService.forceRevokeAccessUsersOnDatabase(supportedGatekeeperRDSInstance, environment, userList);
+        Mockito.verify(mockDBConnection, Mockito.times(2)).revokeAccess(argumentCaptor.capture());
+        RdsRevokeAccessQuery actualRevokeRequest1 = argumentCaptor.getAllValues().get(0);
+        RdsRevokeAccessQuery actualRevokeRequest2 = argumentCaptor.getAllValues().get(1);
+        expectedRevokeRequest.withUser(gkDbUser.getUsername());
+        Assert.assertEquals(expectedRevokeRequest, actualRevokeRequest1);
+        expectedRevokeRequest.withUser(gkDbUser2.getUsername());
+        Assert.assertEquals(expectedRevokeRequest, actualRevokeRequest2);
+        Assert.assertEquals(Collections.emptyList(), removedUsers);
+    }
+
+    @Test
+    public void testForceRevokeAccessHappyFailedOne() throws Exception {
+        ArgumentCaptor<RdsRevokeAccessQuery> argumentCaptor = ArgumentCaptor.forClass(RdsRevokeAccessQuery.class);
+        gkDbUser2.setUsername("gk_userfail");
+        List<DbUser> userList = Arrays.asList(gkDbUser, gkDbUser2);
+        List<String> removedUsers = databaseConnectionService.forceRevokeAccessUsersOnDatabase(supportedGatekeeperRDSInstance, environment, userList);
+        Mockito.verify(mockDBConnection, Mockito.times(2)).revokeAccess(argumentCaptor.capture());
+        RdsRevokeAccessQuery actualRevokeRequest1 = argumentCaptor.getAllValues().get(0);
+        RdsRevokeAccessQuery actualRevokeRequest2 = argumentCaptor.getAllValues().get(1);
+        expectedRevokeRequest.withUser(gkDbUser.getUsername());
+        Assert.assertEquals(expectedRevokeRequest, actualRevokeRequest1);
+        expectedRevokeRequest.withUser(gkDbUser2.getUsername());
+        Assert.assertEquals(expectedRevokeRequest, actualRevokeRequest2);
+        Assert.assertEquals(Collections.singletonList(gkDbUser2.getUsername()), removedUsers);
+    }
+
+    @Test(expected = GatekeeperException.class)
+    public void testForceRevokeAccessNonGkUserIncluded() throws Exception {
+        List<DbUser> userList = Arrays.asList(gkDbUser, gkDbUser2, nonGkDbUser);
+        List<String> removedUsers = databaseConnectionService.forceRevokeAccessUsersOnDatabase(supportedGatekeeperRDSInstance, environment, userList);
+        Assert.assertEquals(Collections.singletonList(gkDbUser2.getUsername()), removedUsers);
+    }
+
+    /*
+     * getAvailableSchemas UI
+     */
+
+    @Test
+    public void testGetAvailableSchemasForDbUIHappy() throws Exception {
+        ArgumentCaptor<RdsQuery> argumentCaptor = ArgumentCaptor.forClass(RdsQuery.class);
+        Map<RoleType, List<String>> result = databaseConnectionService.getAvailableSchemasForDb(supportedGatekeeperRDSInstance, environment);
+        Mockito.verify(mockDBConnection).getAvailableTables(argumentCaptor.capture());
+        RdsQuery actualCall = argumentCaptor.getValue();
+        Assert.assertEquals(expectedRequest, actualCall);
+        Assert.assertEquals(result.size(), 5);
+    }
+
+    @Test
+    public void testGetAvailableSchemasForDbNonUIHappy() throws Exception {
+        ArgumentCaptor<RdsQuery> argumentCaptor = ArgumentCaptor.forClass(RdsQuery.class);
+        Map<RoleType, List<String>> result = databaseConnectionService.getAvailableSchemasForDb(database, environment);
+        Mockito.verify(mockDBConnection).getAvailableTables(argumentCaptor.capture());
+        RdsQuery actualCall = argumentCaptor.getValue();
+        Assert.assertEquals(expectedRequest, actualCall);
+        Assert.assertEquals(result.size(), 5);
+    }
+
+    /*
+     * checkDb
+     */
+
+    @Test
+    public void testCheckDbRdsHappy() throws Exception {
+        ArgumentCaptor<RdsQuery> argumentCaptor = ArgumentCaptor.forClass(RdsQuery.class);
+        String result = databaseConnectionService.checkDb(rdsInstance, environment);
+        Mockito.verify(mockDBConnection).checkDb(argumentCaptor.capture());
+        RdsQuery actualCall = argumentCaptor.getValue();
+        Assert.assertEquals(expectedRequest, actualCall);
+        Assert.assertEquals("", result);
+    }
+
+    @Test
+    public void testCheckDbRdsUnhappy() throws Exception {
+        rdsInstance.setDBInstanceIdentifier("failthetest");
+        String result = databaseConnectionService.checkDb(rdsInstance, environment);
+        Assert.assertEquals("Failed", result);
+    }
+
+    @Test
+    public void testCheckDbAuroraHappy() throws Exception {
+        ArgumentCaptor<RdsQuery> argumentCaptor = ArgumentCaptor.forClass(RdsQuery.class);
+        String result = databaseConnectionService.checkDb(auroraCluster, environment);
+        Mockito.verify(mockDBConnection).checkDb(argumentCaptor.capture());
+        RdsQuery actualCall = argumentCaptor.getValue();
+        Assert.assertEquals(expectedRequest, actualCall);
+        Assert.assertEquals("", result);
+    }
+
+    @Test
+    public void testCheckDbAuroraUnhappy() throws Exception {
+        auroraCluster.setDBClusterIdentifier("failthetest");
+        String result = databaseConnectionService.checkDb(auroraCluster, environment);
+        Assert.assertEquals("Failed", result);
+    }
+
+    /*
+     * getUsersForDb
+     */
+
+    @Test
+    public void testGetUsersForDb() throws Exception {
+        ArgumentCaptor<RdsQuery> argumentCaptor = ArgumentCaptor.forClass(RdsQuery.class);
+        List<DbUser> result = databaseConnectionService.getUsersForDb(supportedGatekeeperRDSInstance, environment);
+        Mockito.verify(mockDBConnection).getUsers(argumentCaptor.capture());
+        RdsQuery actualCall = argumentCaptor.getValue();
+        Assert.assertEquals(expectedRequest, actualCall);
+        Assert.assertEquals(2, result.size());
+    }
+
+    /*
+     * getAvailableRolesForDb
+     */
+
+    @Test
+    public void testGetAvailableRolesForDbRds() throws Exception {
+        ArgumentCaptor<RdsQuery> argumentCaptor = ArgumentCaptor.forClass(RdsQuery.class);
+        List<String> result = databaseConnectionService.getAvailableRolesForDb(rdsInstance, environment);
+        Mockito.verify(mockDBConnection).getAvailableRoles(argumentCaptor.capture());
+        RdsQuery actualCall = argumentCaptor.getValue();
+        Assert.assertEquals(expectedRequest, actualCall);
+        Assert.assertEquals(3, result.size());
+    }
+
+    @Test
+    public void testGetAvailableRolesForDbAurora() throws Exception {
+        ArgumentCaptor<RdsQuery> argumentCaptor = ArgumentCaptor.forClass(RdsQuery.class);
+        List<String> result = databaseConnectionService.getAvailableRolesForDb(auroraCluster, environment);
+        Mockito.verify(mockDBConnection).getAvailableRoles(argumentCaptor.capture());
+        RdsQuery actualCall = argumentCaptor.getValue();
+        Assert.assertEquals(expectedRequest, actualCall);
+        Assert.assertEquals(3, result.size());
+    }
+
+    /*
+     * checkUsersAndDb
+     */
+
+    @Test
+    public void testCheckUsersAndDbs() throws Exception {
+        ArgumentCaptor<RdsCheckUsersTableQuery> argumentCaptor = ArgumentCaptor.forClass(RdsCheckUsersTableQuery.class);
+        List<UserRole> roles = Arrays.asList(new UserRole().setRole("READONLY"));
+        List<User> users = Arrays.asList(new User().setUserId("happyTestUser"));
+        List<String> result = databaseConnectionService.checkUsersAndDbs(roles, users, database, environment);
+        Mockito.verify(mockDBConnection).checkIfUsersHasTables(argumentCaptor.capture());
+        expectedCheckUsersRequest.withUsers(Arrays.asList("testUserHappy"));
+        RdsCheckUsersTableQuery actualCall = argumentCaptor.getValue();
+        Assert.assertEquals(expectedRequest, actualCall);
+        Assert.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testCheckUsersAndDbsError() throws Exception {
+        ArgumentCaptor<RdsCheckUsersTableQuery> argumentCaptor = ArgumentCaptor.forClass(RdsCheckUsersTableQuery.class);
+        List<UserRole> roles = Arrays.asList(new UserRole().setRole("READONLY"));
+        List<User> users = Arrays.asList(new User().setUserId("testUser"), new User().setUserId("happyTestUser"));
+        List<String> result = databaseConnectionService.checkUsersAndDbs(roles, users, database, environment);
+        Mockito.verify(mockDBConnection).checkIfUsersHasTables(argumentCaptor.capture());
+        expectedCheckUsersRequest.withUsers(Arrays.asList("testUserHappy"));
+        RdsCheckUsersTableQuery actualCall = argumentCaptor.getValue();
+        Assert.assertEquals(expectedRequest, actualCall);
+        Assert.assertTrue(result.isEmpty());
+    }
+}

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/db/mockconnection/MockDBConnection.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/db/mockconnection/MockDBConnection.java
@@ -1,0 +1,66 @@
+package org.finra.gatekeeper.services.db.mockconnection;
+
+import org.finra.gatekeeper.rds.exception.GKUnsupportedDBException;
+import org.finra.gatekeeper.rds.interfaces.DBConnection;
+import org.finra.gatekeeper.rds.model.*;
+
+import java.sql.SQLException;
+import java.util.*;
+
+/**
+ * This class is used to test the DatabaseConnectionService Class
+ */
+public class MockDBConnection implements DBConnection {
+    @Override
+    public boolean grantAccess(RdsGrantAccessQuery rdsGrantAccessQuery) throws Exception {
+        return rdsGrantAccessQuery.getUser().contains("happy");
+    }
+
+    @Override
+    public boolean revokeAccess(RdsRevokeAccessQuery rdsRevokeAccessQuery) throws Exception {
+        return rdsRevokeAccessQuery.getUser().contains("happy");
+    }
+
+    @Override
+    public Map<RoleType, List<String>> getAvailableTables(RdsQuery rdsQuery) throws Exception {
+        Map<RoleType, List<String>> roleTypeListMap = new HashMap<>();
+        roleTypeListMap.put(RoleType.READONLY, Arrays.asList("ro_table1", "ro_table2"));
+        roleTypeListMap.put(RoleType.READONLY_CONFIDENTIAL, Arrays.asList("roc_table1"));
+        roleTypeListMap.put(RoleType.DBA, Arrays.asList("dba_table1", "dba_table2"));
+        roleTypeListMap.put(RoleType.DBA_CONFIDENTIAL, Arrays.asList("dbac_table1"));
+        roleTypeListMap.put(RoleType.DATAFIX, Arrays.asList("df_table1"));
+        return roleTypeListMap;
+    }
+
+    @Override
+    public List<String> checkDb(RdsQuery rdsQuery) throws GKUnsupportedDBException {
+        if(rdsQuery.getDbInstanceName().contains("fail")){
+            return Collections.singletonList("Failed");
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<String> checkIfUsersHasTables(RdsCheckUsersTableQuery rdsCheckUsersTableQuery) throws SQLException {
+        List<String> response = new ArrayList<>();
+        for(String user: rdsCheckUsersTableQuery.getUsers()) {
+            if(!user.contains("happy")){
+                throw new SQLException("An Error Occurred");
+            }
+        }
+        return response;
+    }
+
+    @Override
+    public List<DbUser> getUsers(RdsQuery rdsQuery) throws SQLException {
+        return Arrays.asList(
+                new DbUser().setUsername("gk_test_ro").setRoles(null),
+                new DbUser().setUsername("admin").setRoles(null)
+        );
+    }
+
+    @Override
+    public List<String> getAvailableRoles(RdsQuery rdsQuery) throws SQLException {
+        return Arrays.asList("DBA", "READONLY", "DATAFIX");
+    }
+}

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/db/mockconnection/MockDBConnection.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/db/mockconnection/MockDBConnection.java
@@ -1,3 +1,20 @@
+/*
+ *
+ * Copyright 2020. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.finra.gatekeeper.services.db.mockconnection;
 
 import org.finra.gatekeeper.rds.exception.GKUnsupportedDBException;

--- a/ui/app/component/rds/admin/RdsAdminController.js
+++ b/ui/app/component/rds/admin/RdsAdminController.js
@@ -98,6 +98,7 @@ class RdsAdminController extends GatekeeperAdminController{
             {
                 account: vm.forms.awsInstanceForm.selectedAccount.alias.toLowerCase(),
                 region: vm.forms.awsInstanceForm.selectedRegion.name,
+                sdlc: vm.forms.awsInstanceForm.selectedAccount.sdlc,
                 instanceId: row.instanceId,
                 instanceName: row.name,
             });
@@ -120,6 +121,7 @@ class RdsAdminController extends GatekeeperAdminController{
                 vm.blocking = true;
                 vm.usersTable.promise = vm[REVOKE].delete(vm.forms.awsInstanceForm.selectedAccount.alias.toLowerCase(),
                     vm.forms.awsInstanceForm.selectedRegion.name,
+                    vm.forms.awsInstanceForm.selectedAccount.sdlc,
                     vm.selectedItems[0].instanceId,
                     vm.selectedItems[0].name,
                     vm.usersTable.selected);

--- a/ui/app/component/rds/selfservice/GkRdsSearch.js
+++ b/ui/app/component/rds/selfservice/GkRdsSearch.js
@@ -117,6 +117,7 @@ class GkRdsSearch extends Directive{
                         type: vm.forms.awsInstanceForm.selectedType,
                         account: vm.forms.awsInstanceForm.selectedAccount.alias.toLowerCase(),
                         region: vm.forms.awsInstanceForm.selectedRegion.name,
+                        sdlc: vm.forms.awsInstanceForm.selectedAccount.sdlc,
                         searchText:vm.forms.awsInstanceForm.searchText,
                     });
 

--- a/ui/app/component/rds/selfservice/RdsSchemaDialogController.js
+++ b/ui/app/component/rds/selfservice/RdsSchemaDialogController.js
@@ -34,7 +34,7 @@ class RdsSchemaDialogController {
         this[DIALOG] = $mdDialog;
 
         vm.fetched = false;
-        vm.schemaPromise = gkSchemaService.search({account:account.alias, region: region.name, instanceName: database.name, instanceId: database.instanceId});
+        vm.schemaPromise = gkSchemaService.search({account:account.alias, region: region.name, sdlc: account.sdlc, instanceName: database.name, instanceId: database.instanceId});
         vm.schemaPromise.then((response) => {
             vm.schemas = response.data;
             vm.fetched = true;

--- a/ui/app/component/shared/RDSDataService.js
+++ b/ui/app/component/shared/RDSDataService.js
@@ -28,7 +28,7 @@ class RDSDataService extends SearchableDataService{
     constructor($http,$state){
         super($http,$state);
         this.resource = 'searchDBInstances';
-        this.params= ['type','account','region','searchText'];
+        this.params= ['type','account','region','sdlc','searchText'];
     }
 }
 

--- a/ui/app/component/shared/RdsRevokeUsersDataService.js
+++ b/ui/app/component/shared/RdsRevokeUsersDataService.js
@@ -29,10 +29,11 @@ class RdsRevokeUsersDataService extends DataService{
         this.resource = 'db/removeUsers';
     }
 
-    delete(account, region, instanceId, instanceName, users){
+    delete(account, region, sdlc, instanceId, instanceName, users){
         let bundle = {
             account: account,
             region: region,
+            sdlc: sdlc,
             instanceId: instanceId,
             instanceName: instanceName,
             users: users,

--- a/ui/app/component/shared/RdsUsersDataService.js
+++ b/ui/app/component/shared/RdsUsersDataService.js
@@ -27,7 +27,7 @@ class RdsUsersDataService extends SearchableDataService{
     constructor($http,$state){
         super($http,$state);
         this.resource = 'getUsers';
-        this.params= ['account','region','instanceId','instanceName'];
+        this.params= ['account','region','sdlc','instanceId','instanceName'];
     }
 
 }

--- a/ui/app/component/shared/SchemaDataService.js
+++ b/ui/app/component/shared/SchemaDataService.js
@@ -27,7 +27,7 @@ class SchemaDataService extends SearchableDataService{
     constructor($http,$state){
         super($http,$state);
         this.resource = 'getAvailableSchemas';
-        this.params= ['account','region','instanceId', "instanceName"];
+        this.params= ['account','region','sdlc','instanceId', "instanceName"];
     }
 }
 

--- a/ui/test/unit/specs/rdsadmin.component.spec.js
+++ b/ui/test/unit/specs/rdsadmin.component.spec.js
@@ -145,7 +145,7 @@ describe('GateKeeper RDS admin component', function () {
                let resp = {data:[{username:'testuser'},{username:'another'}]};
                testInit(true);
                controller.forms.awsInstanceForm = {
-                   selectedAccount: { alias:'ut'},
+                   selectedAccount: { alias:'ut', sdlc:'unittest'},
                    selectedRegion: { name:'us-east-1'}
                };
                let row = {name:'testid', instanceId: 'testInstanceId'};
@@ -155,6 +155,7 @@ describe('GateKeeper RDS admin component', function () {
                expect(gkRdsUserService.search).toHaveBeenCalledWith({
                    account:controller.forms.awsInstanceForm.selectedAccount.alias,
                    region:controller.forms.awsInstanceForm.selectedRegion.name,
+                   sdlc:controller.forms.awsInstanceForm.selectedAccount.sdlc,
                    instanceId: row.instanceId,
                    instanceName:row.name
                });


### PR DESCRIPTION
Re-worked how credentials are managed with the Gatekeeper RDS service, by default the system will use the original method of getting the Gatekeeper user password (through direct configuration/environment variable) but the interface to doing this has been abstracted out similar to the DBConnection interface.

This change also re-works how the DBConnection interface to be more object-defined as the number of arguments is increasing to account for the fact we're allowing users to be more sophisticated with how they manage the gatekeeper user's credentials on their DB's