### PR TITLE
Some Fixes for issues that came up during testing in lower environment:

### DIFF
--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/RdsLookupService.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/RdsLookupService.java
@@ -198,6 +198,7 @@ public class RdsLookupService {
                         // if the SSL Option is present then set the port and stop searching
                         if(sslOption.isPresent()){
                             port = sslOption.get().getPort();
+                            item.getEndpoint().setPort(port); //for oracle need to set the ssl port to be different.
                             break;
                         }
                     }
@@ -255,6 +256,12 @@ public class RdsLookupService {
         ArrayList<GatekeeperRDSInstance> gatekeeperRDSInstances = new ArrayList<>();
 
         instances.forEach(item -> {
+            // Only concerned with Aurora clusters apparently AWS lumps in docdb and neptune, etc clusters with the call on the RDS API
+            // if the engine is not aurora then skip it.
+            if(!item.getEngine().contains("aurora")){
+                return;
+            }
+
             String application = getApplicationTagforInstanceArn(client, item.getDBClusterArn());
             boolean enabled = false;
             String status = item.getStatus();


### PR DESCRIPTION
1. For instances using non standard ports a change was missed where the ports were no longer being passed along with the endpoint, this is addressed in the checkDb method for both aurora and rds
2. The AWS RDS SDK for looking at clusters also pulls in DocumentDB and other thing such as Neptune, Gatekeeper does not support these and this change effectively filters out these resources.

Signed-off-by: Stephen Mele <Smelecs@gmail.com>