### PR TITLE
Aurora global

### DIFF
--- a/services/common/pom.xml
+++ b/services/common/pom.xml
@@ -15,7 +15,7 @@
     </parent>
 
     <properties>
-        <aws.sdk.version>1.11.333</aws.sdk.version>
+        <aws.sdk.version>1.11.800</aws.sdk.version>
         <java.version>1.8</java.version>
         <freemarker.version>2.3.20</freemarker.version>
         <commons.version>3.4</commons.version>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -198,11 +198,4 @@
             </plugin>
         </plugins>
     </build>
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>GitHub</name>
-            <url>https://maven.pkg.github.com/SMxJrz</url>
-        </repository>
-    </distributionManagement>
 </project>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <activiti.version>5.20.0</activiti.version>
-        <aws.sdk.version>1.11.333</aws.sdk.version>
+        <aws.sdk.version>1.11.800</aws.sdk.version>
         <compiler.version>3.3</compiler.version>
         <failsafe.version>2.18.1</failsafe.version>
         <guava.version>24.0-jre</guava.version>
@@ -198,4 +198,11 @@
             </plugin>
         </plugins>
     </build>
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub</name>
+            <url>https://maven.pkg.github.com/SMxJrz</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/services/rds/pom.xml
+++ b/services/rds/pom.xml
@@ -33,7 +33,7 @@
 
 	<properties>
 		<activiti.version>5.20.0</activiti.version>
-        <aws.sdk.version>1.11.333</aws.sdk.version>
+        <aws.sdk.version>1.11.800</aws.sdk.version>
 		<compiler.version>3.3</compiler.version>
 		<failsafe.version>2.19.1</failsafe.version>
 		<freemarker.version>2.3.29</freemarker.version>
@@ -116,6 +116,11 @@
 			<groupId>org.mariadb.jdbc</groupId>
 			<artifactId>mariadb-java-client</artifactId>
 			<version>2.2.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-core</artifactId>
+			<version>${aws.sdk.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/delegates/RevokeAccessServiceTask.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/delegates/RevokeAccessServiceTask.java
@@ -17,6 +17,7 @@
 
 package org.finra.gatekeeper.services.accessrequest.delegates;
 
+import com.amazonaws.services.rds.model.DBCluster;
 import org.activiti.engine.ManagementService;
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.delegate.JavaDelegate;
@@ -26,13 +27,13 @@ import org.finra.gatekeeper.services.accessrequest.model.AWSRdsDatabase;
 import org.finra.gatekeeper.services.accessrequest.model.AccessRequest;
 import org.finra.gatekeeper.services.accessrequest.model.User;
 import org.finra.gatekeeper.services.accessrequest.model.UserRole;
+import org.finra.gatekeeper.services.aws.RdsLookupService;
 import org.finra.gatekeeper.services.aws.model.AWSEnvironment;
 import org.finra.gatekeeper.services.db.DatabaseConnectionService;
 import org.finra.gatekeeper.services.email.wrappers.EmailServiceWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /**
@@ -45,15 +46,18 @@ public class RevokeAccessServiceTask implements JavaDelegate {
 
     private final EmailServiceWrapper emailServiceWrapper;
     private final DatabaseConnectionService databaseConnectionService;
+    private final RdsLookupService rdsLookupService;
     private final ManagementService managementService;
 
     @Autowired
     public RevokeAccessServiceTask(EmailServiceWrapper emailServiceWrapper,
                                    DatabaseConnectionService databaseConnectionService,
-                                   ManagementService managementService) {
+                                   ManagementService managementService,
+                                   RdsLookupService rdsLookupService) {
         this.emailServiceWrapper = emailServiceWrapper;
         this.databaseConnectionService = databaseConnectionService;
         this.managementService = managementService;
+        this.rdsLookupService = rdsLookupService;
     }
 
     /***
@@ -69,6 +73,13 @@ public class RevokeAccessServiceTask implements JavaDelegate {
             for(User user : accessRequest.getUsers()){
                 for(UserRole role : accessRequest.getRoles()) {
                     AWSRdsDatabase database = accessRequest.getAwsRdsInstances().get(0);
+                    // if the db was actually an aurora global cluster then we should re-fetch the primary cluster
+                    // as that could have changed
+                    if(database.getGlobalCluster() != null && database.getGlobalCluster() == true){
+                        logger.info("Re-fetching the Primary Cluster for this global cluster since it could have changed over time.");
+                        DBCluster primaryCluster = rdsLookupService.getPrimaryClusterForGlobalCluster(awsEnvironment, database.getName()).get();
+                        database.setEndpoint(String.format("%s:%s", primaryCluster.getEndpoint(), primaryCluster.getPort()));
+                    }
                     databaseConnectionService.revokeAccess(database, awsEnvironment, RoleType.valueOf(role.getRole().toUpperCase()), user.getUserId());
                 }
             }

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/delegates/RevokeAccessServiceTask.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/delegates/RevokeAccessServiceTask.java
@@ -29,6 +29,7 @@ import org.finra.gatekeeper.services.accessrequest.model.User;
 import org.finra.gatekeeper.services.accessrequest.model.UserRole;
 import org.finra.gatekeeper.services.aws.RdsLookupService;
 import org.finra.gatekeeper.services.aws.model.AWSEnvironment;
+import org.finra.gatekeeper.services.aws.model.DatabaseType;
 import org.finra.gatekeeper.services.db.DatabaseConnectionService;
 import org.finra.gatekeeper.services.email.wrappers.EmailServiceWrapper;
 import org.slf4j.Logger;
@@ -75,7 +76,7 @@ public class RevokeAccessServiceTask implements JavaDelegate {
                     AWSRdsDatabase database = accessRequest.getAwsRdsInstances().get(0);
                     // if the db was actually an aurora global cluster then we should re-fetch the primary cluster
                     // as that could have changed
-                    if(database.getGlobalCluster() != null && database.getGlobalCluster() == true){
+                    if(database.getDatabaseType() != null && database.getDatabaseType() == DatabaseType.AURORA_GLOBAL){
                         logger.info("Re-fetching the Primary Cluster for this global cluster since it could have changed over time.");
                         DBCluster primaryCluster = rdsLookupService.getPrimaryClusterForGlobalCluster(awsEnvironment, database.getName()).get();
                         database.setEndpoint(String.format("%s:%s", primaryCluster.getEndpoint(), primaryCluster.getPort()));

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/model/AWSRdsDatabase.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/model/AWSRdsDatabase.java
@@ -38,6 +38,7 @@ public class AWSRdsDatabase {
     private String endpoint;
     private String arn;
     private String status;
+    private Boolean globalCluster;
 
     @ManyToOne
     private AccessRequest accessRequest;
@@ -161,12 +162,22 @@ public class AWSRdsDatabase {
         this.status = status;
         return this;
     }
+
+    public Boolean getGlobalCluster() {
+        return globalCluster;
+    }
+
+    public AWSRdsDatabase setGlobalCluster(Boolean global) {
+        this.globalCluster = global;
+        return this;
+    }
+
     /**
      * Constructors
      */
     public AWSRdsDatabase() {}
 
-    public AWSRdsDatabase(String name, String dbName, String application, String instanceId, String engine, String endpoint, String arn, String status) {
+    public AWSRdsDatabase(String name, String dbName, String application, String instanceId, String engine, String endpoint, String arn, String status, Boolean globalCluster) {
         this.name = name;
         this.dbName = dbName;
         this.application = application;
@@ -175,6 +186,7 @@ public class AWSRdsDatabase {
         this.endpoint = endpoint;
         this.arn = arn;
         this.status = status;
+        this.globalCluster = globalCluster;
     }
 
     @Override
@@ -196,12 +208,13 @@ public class AWSRdsDatabase {
                 && Objects.equals(instanceId, that.instanceId)
                 && Objects.equals(endpoint, that.endpoint)
                 && Objects.equals(status, that.status)
-                && Objects.equals(endpoint, that.endpoint);
+                && Objects.equals(endpoint, that.endpoint)
+                && Objects.equals(globalCluster, that.globalCluster);
     }
 
     @Override
     public int hashCode(){
-        return Objects.hash(id, application, name, dbName, instanceId, engine, endpoint, status);
+        return Objects.hash(id, application, name, dbName, instanceId, engine, endpoint, status, globalCluster);
     }
 
     @Override
@@ -216,6 +229,7 @@ public class AWSRdsDatabase {
                 .add("RDS Database Endpoint", endpoint)
                 .add("RDS Database ARN", arn)
                 .add("Status", status)
+                .add("Global", globalCluster)
                 .toString();
     }
 }

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/model/AWSRdsDatabase.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/model/AWSRdsDatabase.java
@@ -18,6 +18,7 @@
 package org.finra.gatekeeper.services.accessrequest.model;
 
 import com.google.common.base.MoreObjects;
+import org.finra.gatekeeper.services.aws.model.DatabaseType;
 
 import javax.persistence.*;
 import java.util.Objects;
@@ -38,7 +39,7 @@ public class AWSRdsDatabase {
     private String endpoint;
     private String arn;
     private String status;
-    private Boolean globalCluster;
+    private DatabaseType databaseType;
 
     @ManyToOne
     private AccessRequest accessRequest;
@@ -163,12 +164,13 @@ public class AWSRdsDatabase {
         return this;
     }
 
-    public Boolean getGlobalCluster() {
-        return globalCluster;
+    @Enumerated(EnumType.STRING)
+    public DatabaseType getDatabaseType() {
+        return databaseType;
     }
 
-    public AWSRdsDatabase setGlobalCluster(Boolean global) {
-        this.globalCluster = global;
+    public AWSRdsDatabase setDatabaseType(DatabaseType global) {
+        this.databaseType = global;
         return this;
     }
 
@@ -177,7 +179,7 @@ public class AWSRdsDatabase {
      */
     public AWSRdsDatabase() {}
 
-    public AWSRdsDatabase(String name, String dbName, String application, String instanceId, String engine, String endpoint, String arn, String status, Boolean globalCluster) {
+    public AWSRdsDatabase(String name, String dbName, String application, String instanceId, String engine, String endpoint, String arn, String status, DatabaseType databaseType) {
         this.name = name;
         this.dbName = dbName;
         this.application = application;
@@ -186,7 +188,7 @@ public class AWSRdsDatabase {
         this.endpoint = endpoint;
         this.arn = arn;
         this.status = status;
-        this.globalCluster = globalCluster;
+        this.databaseType = databaseType;
     }
 
     @Override
@@ -209,12 +211,12 @@ public class AWSRdsDatabase {
                 && Objects.equals(endpoint, that.endpoint)
                 && Objects.equals(status, that.status)
                 && Objects.equals(endpoint, that.endpoint)
-                && Objects.equals(globalCluster, that.globalCluster);
+                && Objects.equals(databaseType, that.databaseType);
     }
 
     @Override
     public int hashCode(){
-        return Objects.hash(id, application, name, dbName, instanceId, engine, endpoint, status, globalCluster);
+        return Objects.hash(id, application, name, dbName, instanceId, engine, endpoint, status, databaseType);
     }
 
     @Override
@@ -229,7 +231,7 @@ public class AWSRdsDatabase {
                 .add("RDS Database Endpoint", endpoint)
                 .add("RDS Database ARN", arn)
                 .add("Status", status)
-                .add("Global", globalCluster)
+                .add("Database Type", databaseType)
                 .toString();
     }
 }

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/DatabaseType.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/DatabaseType.java
@@ -16,6 +16,6 @@
  */
 package org.finra.gatekeeper.services.aws.model;
 
-public enum LookupType {
+public enum DatabaseType {
     RDS, AURORA_REGIONAL, AURORA_GLOBAL
 }

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/GatekeeperRDSInstance.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/GatekeeperRDSInstance.java
@@ -35,11 +35,11 @@ public class GatekeeperRDSInstance {
     private String endpoint;
     private String application;
     private List<String> availableRoles;
+    private DatabaseType databaseType;
     private boolean enabled;
-    private boolean globalCluster;
 
     public GatekeeperRDSInstance(String instanceId, String name, String dbName, String engine, String status, String arn, String endpoint,
-                                 String application, List<String> availableRoles, Boolean enabled, Boolean globalCluster){
+                                 String application, List<String> availableRoles, Boolean enabled, DatabaseType databaseType){
         this.instanceId = instanceId;
         this.name = name;
         this.dbName = dbName;
@@ -50,7 +50,7 @@ public class GatekeeperRDSInstance {
         this.application = application;
         this.availableRoles = availableRoles;
         this.enabled = enabled;
-        this.globalCluster = globalCluster;
+        this.databaseType = databaseType;
     }
 
     public String getInstanceId() {
@@ -143,12 +143,12 @@ public class GatekeeperRDSInstance {
         return this;
     }
 
-    public boolean isGlobalCluster() {
-        return globalCluster;
+    public DatabaseType getDatabaseType() {
+        return databaseType;
     }
 
-    public GatekeeperRDSInstance setGlobalCluster(boolean globalCluster) {
-        this.globalCluster = globalCluster;
+    public GatekeeperRDSInstance setDatabaseType(DatabaseType globalCluster) {
+        this.databaseType = globalCluster;
         return this;
     }
 
@@ -173,12 +173,12 @@ public class GatekeeperRDSInstance {
                 && Objects.equals(this.application, that.getApplication())
                 && Objects.equals(this.availableRoles, that.getAvailableRoles())
                 && Objects.equals(this.enabled, that.getEnabled())
-                && Objects.equals(this.globalCluster, that.isGlobalCluster());
+                && Objects.equals(this.databaseType, that.getDatabaseType());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(instanceId, name, dbName, engine, status, arn, endpoint, application, availableRoles, enabled, globalCluster);
+        return Objects.hash(instanceId, name, dbName, engine, status, arn, endpoint, application, availableRoles, enabled, databaseType);
     }
 
     @Override
@@ -194,7 +194,7 @@ public class GatekeeperRDSInstance {
                 .add("Application", application)
                 .add("Available Roles", availableRoles)
                 .add("Enabled?", enabled)
-                .add("Global Cluster", globalCluster)
+                .add("Database Type", databaseType)
                 .toString();
     }
 }

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/GatekeeperRDSInstance.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/GatekeeperRDSInstance.java
@@ -36,8 +36,10 @@ public class GatekeeperRDSInstance {
     private String application;
     private List<String> availableRoles;
     private boolean enabled;
+    private boolean globalCluster;
 
-    public GatekeeperRDSInstance(String instanceId, String name, String dbName, String engine, String status, String arn, String endpoint, String application, List<String> availableRoles, Boolean enabled){
+    public GatekeeperRDSInstance(String instanceId, String name, String dbName, String engine, String status, String arn, String endpoint,
+                                 String application, List<String> availableRoles, Boolean enabled, Boolean globalCluster){
         this.instanceId = instanceId;
         this.name = name;
         this.dbName = dbName;
@@ -48,32 +50,108 @@ public class GatekeeperRDSInstance {
         this.application = application;
         this.availableRoles = availableRoles;
         this.enabled = enabled;
+        this.globalCluster = globalCluster;
     }
 
-    public String getInstanceId(){
+    public String getInstanceId() {
         return instanceId;
     }
 
-    public String getEngine(){
+    public GatekeeperRDSInstance setInstanceId(String instanceId) {
+        this.instanceId = instanceId;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public GatekeeperRDSInstance setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getDbName() {
+        return dbName;
+    }
+
+    public GatekeeperRDSInstance setDbName(String dbName) {
+        this.dbName = dbName;
+        return this;
+    }
+
+    public String getEngine() {
         return engine;
     }
 
-    public String getStatus(){
+    public GatekeeperRDSInstance setEngine(String engine) {
+        this.engine = engine;
+        return this;
+    }
+
+    public String getStatus() {
         return status;
     }
 
-    public String getName() { return name; }
+    public GatekeeperRDSInstance setStatus(String status) {
+        this.status = status;
+        return this;
+    }
 
-    public String getDbName() { return  dbName; }
+    public String getArn() {
+        return arn;
+    }
 
-    public String getArn() { return arn; }
+    public GatekeeperRDSInstance setArn(String arn) {
+        this.arn = arn;
+        return this;
+    }
 
-    public String getEndpoint() { return endpoint; }
+    public String getEndpoint() {
+        return endpoint;
+    }
 
-    public String getApplication() { return application; }
+    public GatekeeperRDSInstance setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+        return this;
+    }
 
-    public List<String> getAvailableRoles() { return availableRoles; }
-    public Boolean getEnabled() { return enabled;}
+    public String getApplication() {
+        return application;
+    }
+
+    public GatekeeperRDSInstance setApplication(String application) {
+        this.application = application;
+        return this;
+    }
+
+    public List<String> getAvailableRoles() {
+        return availableRoles;
+    }
+
+    public GatekeeperRDSInstance setAvailableRoles(List<String> availableRoles) {
+        this.availableRoles = availableRoles;
+        return this;
+    }
+
+    public boolean getEnabled() {
+        return enabled;
+    }
+
+    public GatekeeperRDSInstance setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public boolean isGlobalCluster() {
+        return globalCluster;
+    }
+
+    public GatekeeperRDSInstance setGlobalCluster(boolean globalCluster) {
+        this.globalCluster = globalCluster;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o){
         if(this == o){
@@ -94,12 +172,13 @@ public class GatekeeperRDSInstance {
                 && Objects.equals(this.endpoint, that.getEndpoint())
                 && Objects.equals(this.application, that.getApplication())
                 && Objects.equals(this.availableRoles, that.getAvailableRoles())
-                && Objects.equals(this.enabled, that.getEnabled());
+                && Objects.equals(this.enabled, that.getEnabled())
+                && Objects.equals(this.globalCluster, that.isGlobalCluster());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(instanceId, name, dbName, engine, status, arn, endpoint, application, availableRoles, enabled);
+        return Objects.hash(instanceId, name, dbName, engine, status, arn, endpoint, application, availableRoles, enabled, globalCluster);
     }
 
     @Override
@@ -115,6 +194,7 @@ public class GatekeeperRDSInstance {
                 .add("Application", application)
                 .add("Available Roles", availableRoles)
                 .add("Enabled?", enabled)
+                .add("Global Cluster", globalCluster)
                 .toString();
     }
 }

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/LookupType.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/aws/model/LookupType.java
@@ -17,5 +17,5 @@
 package org.finra.gatekeeper.services.aws.model;
 
 public enum LookupType {
-    RDS, AURORA
+    RDS, AURORA_REGIONAL, AURORA_GLOBAL
 }

--- a/services/rds/src/main/resources/emails/accessGranted.ftl
+++ b/services/rds/src/main/resources/emails/accessGranted.ftl
@@ -11,7 +11,7 @@
     <div><h4>Databases</h4></div>
     <ul>
         <#list request.getAwsRdsInstances() as db>
-            <li><b>${db.getInstanceId()}</b> -- ${db.getName()?has_content?string(db.getName(), 'Unknown')} -- ${db.getEngine()}</li>
+            <li><b>${db.getInstanceId()}</b> -- ${db.getName()?has_content?string(db.getName(), 'Unknown')} -- ${db.getEngine()} (${db.getEndpoint()})</li>
         </#list>
     </ul>
     <div>

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/aws/RdsLookupServiceTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/aws/RdsLookupServiceTest.java
@@ -25,6 +25,7 @@ import org.finra.gatekeeper.rds.interfaces.GKUserCredentialsProvider;
 import org.finra.gatekeeper.services.accessrequest.model.AWSRdsDatabase;
 import org.finra.gatekeeper.services.aws.model.AWSEnvironment;
 import org.finra.gatekeeper.services.aws.model.GatekeeperRDSInstance;
+import org.finra.gatekeeper.services.aws.model.LookupType;
 import org.finra.gatekeeper.services.db.DatabaseConnectionService;
 import org.junit.Assert;
 import org.junit.Before;
@@ -138,11 +139,11 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstancesFilter(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "RDS", "gk");
+        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk");
         Assert.assertEquals(8, instances.size());
-        instances = rdsLookupService.getInstances(test, "RDS", "gk-A");
+        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-A");
         Assert.assertEquals(1, instances.size());
-        instances = rdsLookupService.getInstances(test, "RDS", "gk-B");
+        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-B");
         Assert.assertEquals(0, instances.size());
     }
 
@@ -150,7 +151,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstancesHappy(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "RDS", "gk-A");
+        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-A");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertTrue(instance.getEnabled());
@@ -163,7 +164,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstancesMissingSgs(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "RDS", "gk-C");
+        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-C");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_MISSING_SGS, instance.getStatus());
@@ -174,7 +175,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstancesMissingReadReplica(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "RDS", "gk-D");
+        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-D");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals("Unsupported (Read-Only replica of replica1)", instance.getStatus());
@@ -185,7 +186,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstancesUnsupported(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "RDS", "gk-E");
+        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-E");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_UNSUPPORTED_DB_ENGINE, instance.getStatus());
@@ -196,7 +197,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstanceMisconfiguredUser(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "RDS", "gk-F");
+        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-F");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals("Gatekeeper user missing createrole", instance.getStatus());
@@ -207,7 +208,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstanceCantGetRoles(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "RDS", "gk-G");
+        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-G");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_COULD_NOT_FETCH_ROLES, instance.getStatus());
@@ -218,7 +219,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstanceCantLogin(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "RDS", "gk-H");
+        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-H");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_UNABLE_TO_LOGIN, instance.getStatus());
@@ -229,7 +230,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstanceOracle(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "RDS", "gk-I");
+        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-I");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals("TEST", instance.getApplication());
@@ -243,13 +244,13 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstancesFilter(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "AURORA", "gk");
+        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk");
         Assert.assertEquals(10, instances.size());
-        instances = rdsLookupService.getInstances(test, "AURORA", "gk-A");
+        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-A");
         Assert.assertEquals(1, instances.size());
-        instances = rdsLookupService.getInstances(test, "AURORA", "cluster-gk2");
+        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "cluster-gk2");
         Assert.assertEquals(1, instances.size());
-        instances = rdsLookupService.getInstances(test, "AURORA", "clusta-gk2");
+        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "clusta-gk2");
         Assert.assertEquals(0, instances.size());
     }
 
@@ -257,7 +258,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstancesHappy(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "AURORA", "gk-A");
+        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-A");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertTrue(instance.getEnabled());
@@ -270,7 +271,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstancesReadReplica(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "AURORA", "gk-C");
+        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-C");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals("Unsupported (Read-Only replica of replica1)", instance.getStatus());
@@ -281,7 +282,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstancesStopped(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "AURORA", "gk-B");
+        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-B");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(STATUS_STOPPED, instance.getStatus());
@@ -292,7 +293,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstancesMissingSgs(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "AURORA", "gk-D");
+        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-D");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_MISSING_SGS, instance.getStatus());
@@ -303,7 +304,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstancesEmptyCluster(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "AURORA", "gk-E");
+        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-E");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_NO_INSTANCES, instance.getStatus());
@@ -314,7 +315,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstancesNoWriters(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "AURORA", "gk-F");
+        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-F");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_NO_WRITERS, instance.getStatus());
@@ -325,7 +326,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstanceUnsupported(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "AURORA", "gk-G");
+        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-G");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_UNSUPPORTED_DB_ENGINE, instance.getStatus());
@@ -336,7 +337,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstanceMisconfiguredUser(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "AURORA", "gk-H");
+        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-H");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals("Gatekeeper user missing createrole", instance.getStatus());
@@ -347,7 +348,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstanceCantGetRoles(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "AURORA", "gk-I");
+        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-I");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_COULD_NOT_FETCH_ROLES, instance.getStatus());
@@ -358,7 +359,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstanceCantLogin(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, "AURORA", "gk-J");
+        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-J");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_UNABLE_TO_LOGIN, instance.getStatus());

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/aws/RdsLookupServiceTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/aws/RdsLookupServiceTest.java
@@ -25,12 +25,14 @@ import org.finra.gatekeeper.rds.interfaces.GKUserCredentialsProvider;
 import org.finra.gatekeeper.services.accessrequest.model.AWSRdsDatabase;
 import org.finra.gatekeeper.services.aws.model.AWSEnvironment;
 import org.finra.gatekeeper.services.aws.model.GatekeeperRDSInstance;
-import org.finra.gatekeeper.services.aws.model.LookupType;
+import org.finra.gatekeeper.services.aws.model.DatabaseType;
 import org.finra.gatekeeper.services.db.DatabaseConnectionService;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -56,6 +58,11 @@ public class RdsLookupServiceTest {
 
     private RdsLookupService rdsLookupService;
     private AWSEnvironment test;
+
+    @Captor
+    private ArgumentCaptor<DescribeDBClustersRequest> captor;
+    @Captor
+    private ArgumentCaptor<List<DBCluster>> dbClusterCaptor;
 
     private final String RDS_ENGINE_PG = "postgres";
     private final String RDS_ENGINE_ORACLE = "oracle";
@@ -111,6 +118,7 @@ public class RdsLookupServiceTest {
         //AURORA
         Mockito.when(amazonRDSClient.describeDBClusters(Mockito.any())).thenReturn(initializeClusters());
         Mockito.when(amazonRDSClient.listTagsForResource(Mockito.any())).thenReturn(initializeTags());
+        Mockito.when(amazonRDSClient.describeGlobalClusters(Mockito.any())).thenReturn(initializeGlobalClusters());
         Mockito.when(sgLookupService.fetchSgsForAccountRegion(test)).thenReturn(Arrays.asList(SG_ONE, SG_TWO));
         Mockito.when(databaseConnectionService.checkDb(Mockito.eq(clusterA), Mockito.any())).thenReturn("");
         Mockito.when(databaseConnectionService.checkDb(Mockito.eq(clusterB), Mockito.any())).thenReturn("");
@@ -139,11 +147,11 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstancesFilter(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk");
+        instances = rdsLookupService.getInstances(test, DatabaseType.RDS.toString(), "gk");
         Assert.assertEquals(8, instances.size());
-        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-A");
+        instances = rdsLookupService.getInstances(test, DatabaseType.RDS.toString(), "gk-A");
         Assert.assertEquals(1, instances.size());
-        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-B");
+        instances = rdsLookupService.getInstances(test, DatabaseType.RDS.toString(), "gk-B");
         Assert.assertEquals(0, instances.size());
     }
 
@@ -151,7 +159,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstancesHappy(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-A");
+        instances = rdsLookupService.getInstances(test, DatabaseType.RDS.toString(), "gk-A");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertTrue(instance.getEnabled());
@@ -164,7 +172,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstancesMissingSgs(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-C");
+        instances = rdsLookupService.getInstances(test, DatabaseType.RDS.toString(), "gk-C");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_MISSING_SGS, instance.getStatus());
@@ -175,7 +183,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstancesMissingReadReplica(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-D");
+        instances = rdsLookupService.getInstances(test, DatabaseType.RDS.toString(), "gk-D");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals("Unsupported (Read-Only replica of replica1)", instance.getStatus());
@@ -186,7 +194,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstancesUnsupported(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-E");
+        instances = rdsLookupService.getInstances(test, DatabaseType.RDS.toString(), "gk-E");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_UNSUPPORTED_DB_ENGINE, instance.getStatus());
@@ -197,7 +205,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstanceMisconfiguredUser(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-F");
+        instances = rdsLookupService.getInstances(test, DatabaseType.RDS.toString(), "gk-F");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals("Gatekeeper user missing createrole", instance.getStatus());
@@ -208,7 +216,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstanceCantGetRoles(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-G");
+        instances = rdsLookupService.getInstances(test, DatabaseType.RDS.toString(), "gk-G");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_COULD_NOT_FETCH_ROLES, instance.getStatus());
@@ -219,7 +227,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstanceCantLogin(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-H");
+        instances = rdsLookupService.getInstances(test, DatabaseType.RDS.toString(), "gk-H");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_UNABLE_TO_LOGIN, instance.getStatus());
@@ -230,7 +238,7 @@ public class RdsLookupServiceTest {
     public void rdsTestGetInstanceOracle(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.RDS.toString(), "gk-I");
+        instances = rdsLookupService.getInstances(test, DatabaseType.RDS.toString(), "gk-I");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals("TEST", instance.getApplication());
@@ -244,13 +252,13 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstancesFilter(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk");
+        instances = rdsLookupService.getInstances(test, DatabaseType.AURORA_REGIONAL.toString(), "gk");
         Assert.assertEquals(10, instances.size());
-        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-A");
+        instances = rdsLookupService.getInstances(test, DatabaseType.AURORA_REGIONAL.toString(), "gk-A");
         Assert.assertEquals(1, instances.size());
-        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "cluster-gk2");
+        instances = rdsLookupService.getInstances(test, DatabaseType.AURORA_REGIONAL.toString(), "cluster-gk2");
         Assert.assertEquals(1, instances.size());
-        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "clusta-gk2");
+        instances = rdsLookupService.getInstances(test, DatabaseType.AURORA_REGIONAL.toString(), "clusta-gk2");
         Assert.assertEquals(0, instances.size());
     }
 
@@ -258,7 +266,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstancesHappy(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-A");
+        instances = rdsLookupService.getInstances(test, DatabaseType.AURORA_REGIONAL.toString(), "gk-A");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertTrue(instance.getEnabled());
@@ -271,7 +279,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstancesReadReplica(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-C");
+        instances = rdsLookupService.getInstances(test, DatabaseType.AURORA_REGIONAL.toString(), "gk-C");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals("Unsupported (Read-Only replica of replica1)", instance.getStatus());
@@ -282,7 +290,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstancesStopped(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-B");
+        instances = rdsLookupService.getInstances(test, DatabaseType.AURORA_REGIONAL.toString(), "gk-B");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(STATUS_STOPPED, instance.getStatus());
@@ -293,7 +301,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstancesMissingSgs(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-D");
+        instances = rdsLookupService.getInstances(test, DatabaseType.AURORA_REGIONAL.toString(), "gk-D");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_MISSING_SGS, instance.getStatus());
@@ -304,7 +312,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstancesEmptyCluster(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-E");
+        instances = rdsLookupService.getInstances(test, DatabaseType.AURORA_REGIONAL.toString(), "gk-E");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_NO_INSTANCES, instance.getStatus());
@@ -315,7 +323,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstancesNoWriters(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-F");
+        instances = rdsLookupService.getInstances(test, DatabaseType.AURORA_REGIONAL.toString(), "gk-F");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_NO_WRITERS, instance.getStatus());
@@ -326,7 +334,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstanceUnsupported(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-G");
+        instances = rdsLookupService.getInstances(test, DatabaseType.AURORA_REGIONAL.toString(), "gk-G");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_UNSUPPORTED_DB_ENGINE, instance.getStatus());
@@ -337,7 +345,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstanceMisconfiguredUser(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-H");
+        instances = rdsLookupService.getInstances(test, DatabaseType.AURORA_REGIONAL.toString(), "gk-H");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals("Gatekeeper user missing createrole", instance.getStatus());
@@ -348,7 +356,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstanceCantGetRoles(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-I");
+        instances = rdsLookupService.getInstances(test, DatabaseType.AURORA_REGIONAL.toString(), "gk-I");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_COULD_NOT_FETCH_ROLES, instance.getStatus());
@@ -359,7 +367,7 @@ public class RdsLookupServiceTest {
     public void auroraTestGetInstanceCantLogin(){
         List<GatekeeperRDSInstance> instances;
 
-        instances = rdsLookupService.getInstances(test, LookupType.AURORA_REGIONAL.toString(), "gk-J");
+        instances = rdsLookupService.getInstances(test, DatabaseType.AURORA_REGIONAL.toString(), "gk-J");
         Assert.assertEquals(1, instances.size());
         GatekeeperRDSInstance instance = instances.get(0);
         Assert.assertEquals(RdsLookupService.STATUS_UNABLE_TO_LOGIN, instance.getStatus());
@@ -391,13 +399,26 @@ public class RdsLookupServiceTest {
         Assert.assertEquals(new HashSet<>(Arrays.asList("gk_readonly","gk_datafix","gk_dba")), new HashSet<>(instance.get().getAvailableRoles()));
     }
 
+    //AURORA Global
+
+    @Test
+    public void auroraGlobalTestGetInstancesFilter(){
+        // Verify that the aws SDK is only called for the 3 faked aurora global clusters that were provided
+        // This method fetches all of the global clusters that match the text filter and then goes to pull down the primary cluster from the instance.
+        // once it has all of the primary clusters it will then go and make a DescribeDbClusters call with the primary cluster arn's that were part of the global cluster
+        // once that is done it will go and call the regular aurora code with the name of the cluster being set as the name of the global cluster instead.
+
+        rdsLookupService.getInstances(test, DatabaseType.AURORA_GLOBAL.toString(), "gcluster-");
+        Mockito.verify(amazonRDSClient, Mockito.times(1)).describeDBClusters(captor.capture());
+        Assert.assertEquals(3, captor.getValue().getFilters().get(0).getValues().size());
+    }
+
     private DescribeDBInstancesResult initializeInstances(){
         return new DescribeDBInstancesResult().withDBInstances(Arrays.asList(
                 (dbA = initializeInstance("instance1", RDS_ENGINE_PG, "gk-A-instance", "db-gk1", STATUS_AVAILABLE, SG_ONE, null)),
-                (dbB = initializeInstance("instance2", AURORA_ENGINE, "gk-B-instance", "db-gk2", STATUS_AVAILABLE, SG_ONE, null)),
                 (dbC = initializeInstance("instance3", RDS_ENGINE_PG, "gk-C-instance", "db-gk3", STATUS_AVAILABLE, "gk-unsupport", null)),
                 (dbD = initializeInstance("instance4", RDS_ENGINE_PG, "gk-D-instance", "db-gk4", STATUS_AVAILABLE, SG_ONE, "replica1")),
-                (dbE = initializeInstance("unsupported", "sqlserver", "gk-E-instance", "db-gk5", STATUS_AVAILABLE, SG_TWO, null)),
+                (dbE = initializeInstance("unsupported", RDS_ENGINE_PG, "gk-E-instance", "db-gk5", STATUS_AVAILABLE, SG_TWO, null)),
                 (dbF = initializeInstance("missing", RDS_ENGINE_PG, "gk-F-instance", "db-gk6", STATUS_AVAILABLE, SG_TWO, null)),
                 (dbG = initializeInstance("rolesfailunable", RDS_ENGINE_PG, "gk-G-instance", "db-gk7", STATUS_AVAILABLE, SG_TWO, null)),
                 (dbH = initializeInstance("rolesfailpassword", RDS_ENGINE_PG, "gk-H-instance", "db-gk8", STATUS_AVAILABLE, SG_TWO, null)),
@@ -460,6 +481,29 @@ public class RdsLookupServiceTest {
                 .withDBClusterMembers(members)
                 .withReplicationSourceIdentifier(readreplica);
 
+    }
+
+    private DescribeGlobalClustersResult initializeGlobalClusters(){
+        return new DescribeGlobalClustersResult().withGlobalClusters(Arrays.asList(
+                initializeGlobalCluster("gcluster-1", "member1", "reader1"),
+                initializeGlobalCluster("gcluster-2", "member5", "reader2"),
+                initializeGlobalCluster("gcluster-3", "member8", "reader3")
+        ));
+    }
+
+    private GlobalCluster initializeGlobalCluster(String globalClusterId, String primaryClusterId, String readerClusterId){
+        return new GlobalCluster()
+                .withDatabaseName("test")
+                .withEngine("aurora-postgres")
+                .withGlobalClusterIdentifier(globalClusterId)
+                .withGlobalClusterMembers(
+                        new GlobalClusterMember()
+                            .withDBClusterArn(primaryClusterId)
+                            .withIsWriter(true),
+                        new GlobalClusterMember()
+                            .withDBClusterArn(readerClusterId)
+                            .withIsWriter(false)
+                );
     }
     private ListTagsForResourceResult initializeTags(){
         return new ListTagsForResourceResult().withTagList(

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/db/DatabaseConnectionServiceTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/db/DatabaseConnectionServiceTest.java
@@ -95,9 +95,9 @@ public class DatabaseConnectionServiceTest {
                 .setArn("testArn");
 
         supportedGatekeeperRDSInstance = new GatekeeperRDSInstance(database.getInstanceId(), database.getName(), database.getDbName(), database.getEngine(), database.getStatus(), database.getArn(),
-                database.getEndpoint(), database.getApplication(), Arrays.asList("READONLY", "DBA", "DATAFIX"), true);
+                database.getEndpoint(), database.getApplication(), Arrays.asList("READONLY", "DBA", "DATAFIX"), true, false);
         unsupportedGatekeeperRDSInstance = new GatekeeperRDSInstance(database.getInstanceId(), database.getName(), database.getDbName(), TEST_UNSUPPORTED_ENGINE, database.getStatus(), database.getArn(),
-                database.getEndpoint(), database.getApplication(), Arrays.asList("READONLY", "DBA", "DATAFIX"), true);
+                database.getEndpoint(), database.getApplication(), Arrays.asList("READONLY", "DBA", "DATAFIX"), true, false);
         rdsInstance = new DBInstance()
                 .withDBInstanceIdentifier(database.getName())
                 .withEngine(database.getEngine())

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/db/DatabaseConnectionServiceTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/db/DatabaseConnectionServiceTest.java
@@ -29,6 +29,7 @@ import org.finra.gatekeeper.services.accessrequest.model.AWSRdsDatabase;
 import org.finra.gatekeeper.services.accessrequest.model.User;
 import org.finra.gatekeeper.services.accessrequest.model.UserRole;
 import org.finra.gatekeeper.services.aws.model.AWSEnvironment;
+import org.finra.gatekeeper.services.aws.model.DatabaseType;
 import org.finra.gatekeeper.services.aws.model.GatekeeperRDSInstance;
 import org.finra.gatekeeper.services.db.factory.DatabaseConnectionFactory;
 import org.finra.gatekeeper.services.db.mockconnection.MockDBConnection;
@@ -95,9 +96,9 @@ public class DatabaseConnectionServiceTest {
                 .setArn("testArn");
 
         supportedGatekeeperRDSInstance = new GatekeeperRDSInstance(database.getInstanceId(), database.getName(), database.getDbName(), database.getEngine(), database.getStatus(), database.getArn(),
-                database.getEndpoint(), database.getApplication(), Arrays.asList("READONLY", "DBA", "DATAFIX"), true, false);
+                database.getEndpoint(), database.getApplication(), Arrays.asList("READONLY", "DBA", "DATAFIX"), true, DatabaseType.RDS);
         unsupportedGatekeeperRDSInstance = new GatekeeperRDSInstance(database.getInstanceId(), database.getName(), database.getDbName(), TEST_UNSUPPORTED_ENGINE, database.getStatus(), database.getArn(),
-                database.getEndpoint(), database.getApplication(), Arrays.asList("READONLY", "DBA", "DATAFIX"), true, false);
+                database.getEndpoint(), database.getApplication(), Arrays.asList("READONLY", "DBA", "DATAFIX"), true, DatabaseType.RDS);
         rdsInstance = new DBInstance()
                 .withDBInstanceIdentifier(database.getName())
                 .withEngine(database.getEngine())

--- a/ui/app/component/rds/selfservice/GkRdsSearch.js
+++ b/ui/app/component/rds/selfservice/GkRdsSearch.js
@@ -34,12 +34,17 @@ class GkRdsSearch extends Directive{
             selection: '@'
         };
         this.transclude = true;
-        this.controllerAs="ctrl";
+        this.controllerAs = 'ctrl';
     }
 
     controller($scope, $mdDialog, gkRDSService, gkAccountService){
         let vm = this;
-        vm.types = ['RDS', 'Aurora'];
+        vm.types = [
+            {name: 'RDS', key: 'RDS'},
+            {name: 'Aurora (Regional)', key: 'AURORA_REGIONAL'},
+            {name: 'Aurora (Global)', key: 'AURORA_GLOBAL'}
+            ];
+
         vm.rdsService = gkRDSService;
         gkAccountService.fetch().then((response) =>{
             vm.awsAccounts = response.data;
@@ -114,7 +119,7 @@ class GkRdsSearch extends Directive{
                 vm.awsTable.data.splice(0, vm.awsTable.data.length);
                 vm.awsTable.promise = vm.rdsService.search(
                     {
-                        type: vm.forms.awsInstanceForm.selectedType,
+                        type: vm.forms.awsInstanceForm.selectedType.key,
                         account: vm.forms.awsInstanceForm.selectedAccount.alias.toLowerCase(),
                         region: vm.forms.awsInstanceForm.selectedRegion.name,
                         sdlc: vm.forms.awsInstanceForm.selectedAccount.sdlc,
@@ -122,7 +127,6 @@ class GkRdsSearch extends Directive{
                     });
 
                 vm.awsTable.promise.then((response) => {
-                    console.info(response);
                     response.data.forEach((item) => {
                         let roles = '';
                         if(item.availableRoles !== null) {

--- a/ui/app/component/rds/selfservice/template/gatekeeperAWSRdsComponent.tpl.html
+++ b/ui/app/component/rds/selfservice/template/gatekeeperAWSRdsComponent.tpl.html
@@ -23,7 +23,7 @@
                 <md-input-container md-no-float>
                     <label>Select a Type</label>
                     <md-select ng-model="ctrl.forms.awsInstanceForm.selectedType" ng-change="ctrl.clearInstances()" required>
-                        <md-option ng-value="opt" ng-repeat="opt in ctrl.types">{{ opt }}</md-option>
+                        <md-option ng-value="opt" ng-repeat="opt in ctrl.types">{{ opt.name }}</md-option>
                     </md-select>
                 </md-input-container>
             </div>


### PR DESCRIPTION
This updates Gatekeeper RDS to be able to search for and request access to instances that are part of an Aurora Global Cluster.