### PR TITLE
Live requests

### DIFF
--- a/services/rds/src/main/java/org/finra/gatekeeper/controllers/AccessRequestController.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/controllers/AccessRequestController.java
@@ -82,6 +82,13 @@ public class AccessRequestController {
         return accessRequestService.getCompletedRequests();
     }
 
+    @RequestMapping(value = "/getLiveRequests", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<CompletedAccessRequestWrapper> getLiveRequests() {
+        List<CompletedAccessRequestWrapper> liveReqeusts = accessRequestService.getLiveRequests();
+        logger.info(liveReqeusts.toString());
+        return liveReqeusts;
+    }
+
     @RequestMapping(value = "/approveRequest", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
     public Object approveRequest(@RequestBody ActiveAccessRequestWrapper request) {
         return accessRequestService.approveRequest(request.getTaskId(), request.getId(), request.getApproverComments());

--- a/services/rds/src/main/java/org/finra/gatekeeper/controllers/wrappers/CompletedAccessRequestWrapper.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/controllers/wrappers/CompletedAccessRequestWrapper.java
@@ -72,7 +72,17 @@ public class CompletedAccessRequestWrapper extends ActiveAccessRequestWrapper {
         return this;
     }
 
+    public Date getExpirationDate() {
+        return expirationDate;
+    }
+
+    public CompletedAccessRequestWrapper setExpirationDate(Date expirationDate) {
+        this.expirationDate = expirationDate;
+        return this;
+    }
+
     private Date updated;
+    private Date expirationDate;
     private Integer attempts;
     private RequestStatus status;
     private String actionedByUserId;

--- a/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/model/AccessRequestRepository.java
+++ b/services/rds/src/main/java/org/finra/gatekeeper/services/accessrequest/model/AccessRequestRepository.java
@@ -18,9 +18,12 @@
 package org.finra.gatekeeper.services.accessrequest.model;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Repo object for AccessRequest domain
@@ -28,4 +31,88 @@ import java.util.List;
 public interface AccessRequestRepository extends JpaRepository<AccessRequest, Long> {
     AccessRequest getAccessRequestById(Long id);
     List<AccessRequest> getAccessRequestsByIdIn(Collection<Long> ids);
+
+    /**
+     * Gets all live access requests by joining all of the entries into the act_ru_job tables (activiti jobs that monitor expiration)
+     * into the access request table
+     *
+     * @return - AccessRequest objects that are linked to the entry in the act_ru_job table
+     */
+    @Query(value = "select requests.* from ( " +
+            "                  select c.id, b.updated as granted_on, a.duedate_ as expire_time " +
+            "                  from (select process_instance_id_, duedate_ " +
+            "                        from gatekeeper_rds.act_ru_job " +
+            "                        where type_ = 'timer') a, " +
+            "                       (select proc_inst_id_, text2_ as access_req_id, last_updated_time_ as updated " +
+            "                        from gatekeeper_rds.act_hi_varinst " +
+            "                        where name_ = 'accessRequest') b, " +
+            "                       gatekeeper_rds.access_request c " +
+            " " +
+            "                  where a.process_instance_id_ = b.proc_inst_id_ " +
+            "                    and cast(b.access_req_id as numeric) = c.id " +
+            "                  order by access_req_id desc " +
+            "              ) live_requests, " +
+            "              gatekeeper_rds.access_request requests " +
+            "where requests.id = live_requests.id", nativeQuery = true)
+    List<AccessRequest> getLiveAccessRequests();
+
+    @Query(value = "select requests.*, live_requests.granted_on, live_requests.expire_time from (  " +
+            "                  select c.id, b.updated as granted_on, a.duedate_ as expire_time  " +
+            "                  from (select process_instance_id_, duedate_  " +
+            "                        from gatekeeper_rds.act_ru_job  " +
+            "                        where type_ = 'timer') a,  " +
+            "                       (select proc_inst_id_, text2_ as access_req_id, last_updated_time_ as updated  " +
+            "                            from gatekeeper_rds.act_hi_varinst  " +
+            "                            where name_ = 'accessRequest') b,  " +
+            "                       (select * from gatekeeper_rds.access_request requests  " +
+            "                            where account = :account) c,  " +
+            "                       gatekeeper_rds.access_request_users d,  " +
+            "                       (select * from gatekeeper_rds.request_user users  " +
+            "                            where users.user_id = :username) e,  " +
+            "                       gatekeeper_rds.access_request_aws_rds_instances f,  " +
+            "                       (select * from gatekeeper_rds.request_database dbs  " +
+            "                            where dbs.name = :dbname) g,  " +
+            "                       gatekeeper_rds.access_request_roles i,  " +
+            "                       (select * from gatekeeper_rds.request_role roles  " +
+            "                           where roles.role = :role) h  " +
+            "  " +
+            "                  where a.process_instance_id_ = b.proc_inst_id_  " +
+            "                    and cast(b.access_req_id as numeric) = c.id  " +
+            "                    and c.id = d.access_request_id  " +
+            "                    and d.users_id = e.id  " +
+            "                    and c.id = f.access_request_id  " +
+            "                    and f.aws_rds_instances_id = g.id  " +
+            "                    and c.id = i.access_request_id  " +
+            "                    and i.roles_id = h.id  " +
+            "                  order by access_req_id desc  " +
+            "              ) live_requests,  " +
+            "              gatekeeper_rds.access_request requests  " +
+            "where requests.id = live_requests.id", nativeQuery = true)
+    List<AccessRequest> getLiveAccessRequestsForUserAccountDbNameAndRole(@Param("username") String username,
+                                                                         @Param("account") String account,
+                                                                         @Param("dbname") String dbName,
+                                                                         @Param("role") String role);
+
+    /**
+     * This gets all of the Expiration metadata related to the given access request. T
+     * @return a Map<String,Object> containing the following metadata: the ID of the access request, the time the request was granted
+     * and the time the request will expire.
+     */
+    @Query(value = "select requests.id, live_requests.granted_on, live_requests.expire_time from ( " +
+            "                  select c.id, b.updated as granted_on, a.duedate_ as expire_time " +
+            "                  from (select process_instance_id_, duedate_ " +
+            "                        from gatekeeper_rds.act_ru_job " +
+            "                        where type_ = 'timer') a, " +
+            "                       (select proc_inst_id_, text2_ as access_req_id, last_updated_time_ as updated " +
+            "                        from gatekeeper_rds.act_hi_varinst " +
+            "                        where name_ = 'accessRequest') b, " +
+            "                       gatekeeper_rds.access_request c " +
+            " " +
+            "                  where a.process_instance_id_ = b.proc_inst_id_ " +
+            "                    and cast(b.access_req_id as numeric) = c.id " +
+            "                  order by access_req_id desc " +
+            "              ) live_requests, " +
+            "              gatekeeper_rds.access_request requests " +
+            "where requests.id = live_requests.id", nativeQuery = true)
+    List<Map<String, Object>> getLiveAccessRequestExpirations();
 }

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/accessrequest/AccessRequestServiceTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/accessrequest/AccessRequestServiceTest.java
@@ -45,7 +45,6 @@ import org.finra.gatekeeper.common.services.account.model.Account;
 import org.finra.gatekeeper.common.services.account.model.Region;
 import org.finra.gatekeeper.services.auth.model.AppApprovalThreshold;
 import org.finra.gatekeeper.services.auth.model.RoleMembership;
-import org.finra.gatekeeper.services.aws.model.GatekeeperRDSInstance;
 import org.finra.gatekeeper.services.db.DatabaseConnectionService;
 import org.finra.gatekeeper.services.auth.GatekeeperRoleService;
 import org.finra.gatekeeper.services.auth.GatekeeperRdsRole;
@@ -61,6 +60,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.persistence.EntityManager;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.*;
 
 import static org.finra.gatekeeper.services.accessrequest.AccessRequestService.*;
@@ -914,6 +915,38 @@ public class AccessRequestServiceTest {
 
     }
 
+    @Test
+    public void testGetLiveRequests(){
+        Date ownerGranted = Date.from(LocalDateTime.now().toInstant(ZoneOffset.UTC));
+        Date ownerExpires = Date.from(LocalDateTime.now().plusDays(2).toInstant(ZoneOffset.UTC));
+        Date nonOwnerGranted = Date.from(LocalDateTime.now().minusDays(1).toInstant(ZoneOffset.UTC));
+        Date nonOwnerExpires = Date.from(LocalDateTime.now().plusDays(10).toInstant(ZoneOffset.UTC));
+
+        Map<String, Object> ownerRequestExpirations = new HashMap<>();
+        ownerRequestExpirations.put("id", 1L);
+        ownerRequestExpirations.put("granted_on", ownerGranted);
+        ownerRequestExpirations.put("expire_time", ownerExpires);
+
+        Map<String, Object> nonOwnerRequestExpirations = new HashMap<>();
+        nonOwnerRequestExpirations.put("id", 2L);
+        nonOwnerRequestExpirations.put("granted_on", nonOwnerGranted);
+        nonOwnerRequestExpirations.put("expire_time", nonOwnerExpires);
+
+        Mockito.when(accessRequestRepository.getLiveAccessRequests()).thenReturn(Arrays.asList(ownerRequest, nonOwnerRequest));
+        Mockito.when(accessRequestRepository.getLiveAccessRequestExpirations()).thenReturn(Arrays.asList(ownerRequestExpirations, nonOwnerRequestExpirations));
+
+        List<CompletedAccessRequestWrapper> requests = accessRequestService.getLiveRequests();
+        CompletedAccessRequestWrapper ownerResult = requests.get(0);
+        CompletedAccessRequestWrapper nonOwnerResult = requests.get(1);
+
+        Assert.assertEquals(ownerRequest.getId(), ownerResult.getId());
+        Assert.assertEquals(ownerGranted, ownerResult.getUpdated());
+        Assert.assertEquals(ownerExpires, ownerResult.getExpirationDate());
+
+        Assert.assertEquals(nonOwnerResult.getId(), nonOwnerResult.getId());
+        Assert.assertEquals(ownerGranted, ownerResult.getUpdated());
+        Assert.assertEquals(ownerExpires, ownerResult.getExpirationDate());
+    }
 
     private void initRoleMemberships(String application, boolean devMember, boolean opsMember, boolean dbaMember) {
         Map<GatekeeperRdsRole, Set<String>> roleMembershipMap = new HashMap<>();

--- a/services/rds/src/test/java/org/finra/gatekeeper/services/accessrequest/delegates/RevokeAccessServiceTaskTest.java
+++ b/services/rds/src/test/java/org/finra/gatekeeper/services/accessrequest/delegates/RevokeAccessServiceTaskTest.java
@@ -1,0 +1,473 @@
+/*
+ * Copyright 2020. Gatekeeper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.finra.gatekeeper.services.accessrequest.delegates;
+
+import com.amazonaws.services.rds.model.DBCluster;
+import org.activiti.engine.EngineServices;
+import org.activiti.engine.ManagementService;
+import org.activiti.engine.delegate.DelegateExecution;
+import org.activiti.engine.impl.JobQueryImpl;
+import org.activiti.engine.impl.persistence.entity.VariableInstance;
+import org.activiti.engine.runtime.Job;
+import org.finra.gatekeeper.rds.exception.GKUnsupportedDBException;
+import org.finra.gatekeeper.rds.model.RoleType;
+import org.finra.gatekeeper.services.accessrequest.AccessRequestService;
+import org.finra.gatekeeper.services.accessrequest.model.AWSRdsDatabase;
+import org.finra.gatekeeper.services.accessrequest.model.AccessRequest;
+import org.finra.gatekeeper.services.accessrequest.model.User;
+import org.finra.gatekeeper.services.accessrequest.model.UserRole;
+import org.finra.gatekeeper.services.aws.RdsLookupService;
+import org.finra.gatekeeper.services.aws.model.AWSEnvironment;
+import org.finra.gatekeeper.services.aws.model.DatabaseType;
+import org.finra.gatekeeper.services.db.DatabaseConnectionService;
+import org.finra.gatekeeper.services.email.wrappers.EmailServiceWrapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RevokeAccessServiceTaskTest {
+
+    @Mock
+    private EmailServiceWrapper emailServiceWrapper;
+    @Mock
+    private DatabaseConnectionService databaseConnectionService;
+    @Mock
+    private RdsLookupService rdsLookupService;
+    @Mock
+    private ManagementService managementService;
+    @Mock
+    private AccessRequestService accessRequestService;
+    @Mock
+    private MockDelegateExecution mockDelegateExecution;
+    @Mock
+    private MockJob mockJob;
+    @Mock
+    private JobQueryImpl jobQuery;
+
+    @InjectMocks
+    private RevokeAccessServiceTask revokeAccessServiceTask;
+
+    private AccessRequest testRequest;
+
+    @Before
+    public void before(){
+        testRequest = new AccessRequest()
+                .setId(1L)
+                .setDays(1)
+                .setRoles(Arrays.asList(new UserRole()
+                        .setRole("readonly")
+                        .setId(11L)))
+                .setAccount("test")
+                .setAccountSdlc("dev")
+                .setAwsRdsInstances(Arrays.asList(new AWSRdsDatabase()
+                        .setEngine("postgres")
+                        .setEndpoint("jdbc:testEndpont:5432")
+                        .setApplication("TESTAPP")
+                        .setDbName("testdb")
+                        .setInstanceId("db-1234")
+                        .setName("test-database")
+                        .setStatus("APPROVED")
+                        .setArn("arn:12345")
+                        .setDatabaseType(DatabaseType.RDS)))
+                .setUsers(Arrays.asList(new User()
+                        .setId(111L)
+                        .setUserId("gk_test")
+                        .setEmail("testuser@company.com")
+                        .setName("Test User")
+                ))
+                .setRequestorName("Test User")
+                .setRequestReason("Just Unit Testing")
+                .setRegion("us-east-1")
+                .setRequestorId("test");
+
+        Mockito.when(mockDelegateExecution.getProcessInstanceId()).thenReturn("1");
+        Mockito.when(managementService.createJobQuery()).thenReturn(jobQuery);
+        Mockito.when(jobQuery.processInstanceId(Mockito.any())).thenReturn(jobQuery);
+        Mockito.when(jobQuery.singleResult()).thenReturn(mockJob);
+        Mockito.when(mockJob.getRetries()).thenReturn(4);
+        Mockito.when(mockDelegateExecution.getVariable(Mockito.any())).thenReturn(testRequest);
+    }
+
+    @Test
+    public void testRevokeAccessCallsWithExpectedValues() throws Exception {
+        revokeAccessServiceTask.execute(mockDelegateExecution);
+        verifyRevoke();
+    }
+
+    @Test
+    public void testRevokeAccessCallGlobalCluster() throws Exception {
+        ArgumentCaptor<AWSEnvironment> awsEnvironmentArgumentCaptor = ArgumentCaptor.forClass(AWSEnvironment.class);
+        ArgumentCaptor<String> clusterIdCaptor = ArgumentCaptor.forClass(String.class);
+        DBCluster testCluster = new DBCluster().withEndpoint("someendpoint").withPort(5432);
+
+        Mockito.when(rdsLookupService.getPrimaryClusterForGlobalCluster(Mockito.any(), Mockito.any())).thenReturn(Optional.of(testCluster));
+        testRequest.getAwsRdsInstances().get(0).setDatabaseType(DatabaseType.AURORA_GLOBAL);
+
+        revokeAccessServiceTask.execute(mockDelegateExecution);
+        verifyRevoke();
+        Mockito.verify(rdsLookupService, Mockito.times(1)).getPrimaryClusterForGlobalCluster(
+                awsEnvironmentArgumentCaptor.capture(), clusterIdCaptor.capture());
+        Assert.assertEquals(new AWSEnvironment(testRequest.getAccount(), testRequest.getRegion(), testRequest.getAccountSdlc()), awsEnvironmentArgumentCaptor.getValue());
+        Assert.assertEquals(testRequest.getAwsRdsInstances().get(0).getName(), clusterIdCaptor.getValue());
+
+    }
+
+    private void verifyRevoke() throws GKUnsupportedDBException {
+        ArgumentCaptor<String> userIdCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> accountNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> databaseCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<UserRole> roleCaptor = ArgumentCaptor.forClass(UserRole.class);
+
+        Mockito.verify(accessRequestService, Mockito.times(1)).getLiveRequestsForUserOnDatabase(
+                userIdCaptor.capture(), accountNameCaptor.capture(), databaseCaptor.capture(), roleCaptor.capture());
+
+        Assert.assertEquals(testRequest.getUsers().get(0).getUserId(), userIdCaptor.getValue());
+        Assert.assertEquals(testRequest.getAccount(), accountNameCaptor.getValue());
+        Assert.assertEquals(testRequest.getAwsRdsInstances().get(0).getName(), databaseCaptor.getValue());
+        Assert.assertEquals(testRequest.getRoles().get(0), roleCaptor.getValue());
+
+        ArgumentCaptor<AWSRdsDatabase> dbArgumentCaptor = ArgumentCaptor.forClass(AWSRdsDatabase.class);
+        ArgumentCaptor<AWSEnvironment> awsEnvironmentArgumentCaptor = ArgumentCaptor.forClass(AWSEnvironment.class);
+        ArgumentCaptor<RoleType> roleTypeArgumentCaptor = ArgumentCaptor.forClass(RoleType.class);
+
+        Mockito.verify(databaseConnectionService, Mockito.times(1))
+                .revokeAccess(dbArgumentCaptor.capture(),awsEnvironmentArgumentCaptor.capture(),roleTypeArgumentCaptor.capture(),userIdCaptor.capture());
+
+        Assert.assertEquals(testRequest.getAwsRdsInstances().get(0), dbArgumentCaptor.getValue());
+        Assert.assertEquals(new AWSEnvironment(testRequest.getAccount(), testRequest.getRegion(), testRequest.getAccountSdlc()), awsEnvironmentArgumentCaptor.getValue());
+        Assert.assertEquals(testRequest.getRoles().get(0), roleCaptor.getValue());
+        Assert.assertEquals(testRequest.getUsers().get(0).getUserId(), userIdCaptor.getValue());
+    }
+
+    private class MockDelegateExecution implements DelegateExecution {
+        @Override
+        public String getId() {
+            return null;
+        }
+
+        @Override
+        public String getProcessInstanceId() {
+            return null;
+        }
+
+        @Override
+        public String getEventName() {
+            return null;
+        }
+
+        @Override
+        public String getBusinessKey() {
+            return null;
+        }
+
+        @Override
+        public String getProcessBusinessKey() {
+            return null;
+        }
+
+        @Override
+        public String getProcessDefinitionId() {
+            return null;
+        }
+
+        @Override
+        public String getParentId() {
+            return null;
+        }
+
+        @Override
+        public String getSuperExecutionId() {
+            return null;
+        }
+
+        @Override
+        public String getCurrentActivityId() {
+            return null;
+        }
+
+        @Override
+        public String getCurrentActivityName() {
+            return null;
+        }
+
+        @Override
+        public String getTenantId() {
+            return null;
+        }
+
+        @Override
+        public EngineServices getEngineServices() {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> getVariables() {
+            return null;
+        }
+
+        @Override
+        public Map<String, VariableInstance> getVariableInstances() {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> getVariables(Collection<String> collection) {
+            return null;
+        }
+
+        @Override
+        public Map<String, VariableInstance> getVariableInstances(Collection<String> collection) {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> getVariables(Collection<String> collection, boolean b) {
+            return null;
+        }
+
+        @Override
+        public Map<String, VariableInstance> getVariableInstances(Collection<String> collection, boolean b) {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> getVariablesLocal() {
+            return null;
+        }
+
+        @Override
+        public Map<String, VariableInstance> getVariableInstancesLocal() {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> getVariablesLocal(Collection<String> collection) {
+            return null;
+        }
+
+        @Override
+        public Map<String, VariableInstance> getVariableInstancesLocal(Collection<String> collection) {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> getVariablesLocal(Collection<String> collection, boolean b) {
+            return null;
+        }
+
+        @Override
+        public Map<String, VariableInstance> getVariableInstancesLocal(Collection<String> collection, boolean b) {
+            return null;
+        }
+
+        @Override
+        public Object getVariable(String s) {
+            return null;
+        }
+
+        @Override
+        public VariableInstance getVariableInstance(String s) {
+            return null;
+        }
+
+        @Override
+        public Object getVariable(String s, boolean b) {
+            return null;
+        }
+
+        @Override
+        public VariableInstance getVariableInstance(String s, boolean b) {
+            return null;
+        }
+
+        @Override
+        public Object getVariableLocal(String s) {
+            return null;
+        }
+
+        @Override
+        public VariableInstance getVariableInstanceLocal(String s) {
+            return null;
+        }
+
+        @Override
+        public Object getVariableLocal(String s, boolean b) {
+            return null;
+        }
+
+        @Override
+        public VariableInstance getVariableInstanceLocal(String s, boolean b) {
+            return null;
+        }
+
+        @Override
+        public <T> T getVariable(String s, Class<T> aClass) {
+            return null;
+        }
+
+        @Override
+        public <T> T getVariableLocal(String s, Class<T> aClass) {
+            return null;
+        }
+
+        @Override
+        public Set<String> getVariableNames() {
+            return null;
+        }
+
+        @Override
+        public Set<String> getVariableNamesLocal() {
+            return null;
+        }
+
+        @Override
+        public void setVariable(String s, Object o) {
+
+        }
+
+        @Override
+        public void setVariable(String s, Object o, boolean b) {
+
+        }
+
+        @Override
+        public Object setVariableLocal(String s, Object o) {
+            return null;
+        }
+
+        @Override
+        public Object setVariableLocal(String s, Object o, boolean b) {
+            return null;
+        }
+
+        @Override
+        public void setVariables(Map<String, ?> map) {
+
+        }
+
+        @Override
+        public void setVariablesLocal(Map<String, ?> map) {
+
+        }
+
+        @Override
+        public boolean hasVariables() {
+            return false;
+        }
+
+        @Override
+        public boolean hasVariablesLocal() {
+            return false;
+        }
+
+        @Override
+        public boolean hasVariable(String s) {
+            return false;
+        }
+
+        @Override
+        public boolean hasVariableLocal(String s) {
+            return false;
+        }
+
+        @Override
+        public void createVariableLocal(String s, Object o) {
+
+        }
+
+        @Override
+        public void removeVariable(String s) {
+
+        }
+
+        @Override
+        public void removeVariableLocal(String s) {
+
+        }
+
+        @Override
+        public void removeVariables(Collection<String> collection) {
+
+        }
+
+        @Override
+        public void removeVariablesLocal(Collection<String> collection) {
+
+        }
+
+        @Override
+        public void removeVariables() {
+
+        }
+
+        @Override
+        public void removeVariablesLocal() {
+
+        }
+    }
+
+    private class MockJob implements Job {
+
+        @Override
+        public String getId() {
+            return null;
+        }
+
+        @Override
+        public Date getDuedate() {
+            return null;
+        }
+
+        @Override
+        public String getProcessInstanceId() {
+            return null;
+        }
+
+        @Override
+        public String getExecutionId() {
+            return null;
+        }
+
+        @Override
+        public String getProcessDefinitionId() {
+            return null;
+        }
+
+        @Override
+        public int getRetries() {
+            return 0;
+        }
+
+        @Override
+        public String getExceptionMessage() {
+            return null;
+        }
+
+        @Override
+        public String getTenantId() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This PR contains the following:

1. This change adds the capability for the RDS service to fetch live requests,This is primarily used by the Revoke code to check to see if the user should be deleted for a given database.
2. If a user'r request expires for a given role on a given database, but they have another access request open for that role on that database that hasn't expired yet, the application will skip deleting the user from the instance.